### PR TITLE
F #8: add HTTP server to allow for separate oneswap server.

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -53,6 +53,7 @@ require 'command_parser'
 require 'rbvmomi'
 require 'one_helper/oneswap_helper'
 require 'fileutils'
+require 'webrick'
 require 'openssl'
 require 'socket'
 require 'ipaddr'
@@ -307,6 +308,26 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    HTTP_TRANSFER = {
+        :name => 'http_transfer',
+        :large => '--http-transfer',
+        :description => 'Transfer images over HTTP, for use with a separate oneswap server'
+    }
+
+    HTTP_HOST = {
+        :name => 'http_host',
+        :large => '--http-host host',
+        :description => 'IP of this machine to transfer images over HTTP, will also try to detect it if not specified',
+        :format => String
+    }
+
+    HTTP_PORT = {
+        :name => 'http_port',
+        :large => '--http-port port',
+        :description => 'Port to transfer images over HTTP, for use with a separate oneswap server. Default: 29869',
+        :format => Integer
+    }
+
     CONF_FILE = {
         :name => 'config_file',
         :large => '--config-file /path/to/custom/config.yaml',
@@ -315,11 +336,12 @@ CommandParser::CmdParser.new(ARGV) do
     }
 
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
-    V2V_OPTS = [WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY]
+    V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY]
+    HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, V2V_PATH, CONF_FILE,
-                   ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, CONF_FILE,
+                   ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
 
     set :option, CommandParser::OPTIONS + OpenNebulaHelper::CLIENT_OPTIONS
 
@@ -387,6 +409,9 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:config_file] && !File.exist?(options[:config_file])
                 raise "Unable to find the config file at #{options[:config_file]}"
             end
+            cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
+            options.merge!(cfg_file) if cfg_file
+
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
             raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk]
             if options[:hybrid] && ( options[:custom] || options[:esxi_ip] || options[:vddk] )
@@ -408,18 +433,26 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:fallback] && options[:custom_convert]
                 raise "Cannot define both --fallback and --custom."
             end
-            options[:work_dir]     ||= '/tmp'
-            options[:format]       ||= 'qcow2'
-            options[:max_retries]  ||= 0
-            options[:context_path] ||= '/var/lib/one/context/'
-            options[:esxi_user]    ||= 'root'
-            options[:datastore]    ||= 1
-            options[:virt_tools]   ||= '/usr/share/virt-tools'
-            options[:v2v_path]     ||= 'virt-v2v'
-            options[:config_file]  ||= '/var/lib/one/oneswap.yaml'
+            options[:work_dir]      ||= '/tmp'
+            options[:format]        ||= 'qcow2'
+            options[:context]       ||= '/var/lib/one/context/'
+            options[:esxi_user]     ||= 'root'
+            options[:datastore]     ||= 1
+            options[:virt_tools]    ||= '/usr/share/virt-tools'
+            options[:v2v_path]      ||= 'virt-v2v'
+            options[:config_file]   ||= '/var/lib/one/oneswap.yaml'
 
-            cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
-            options.merge!(cfg_file) if cfg_file
+            if options[:http_transfer]
+                options[:http_host] ||= Socket.ip_address_list.detect { |addrinfo| addrinfo.ipv4? && !addrinfo.ipv4_loopback? }&.ip_address
+                if options[:http_host].nil?
+                    raise "Unable to find an IP address for the host"
+                end
+                options[:http_port] ||= 29869
+            else
+                if options[:endpoint]
+                    raise 'Using alternative OpenNebula endpoint requires HTTP Transfer'
+                end
+            end
 
             helper.convert(args[0], options)
         rescue StandardError => e

--- a/oneswap
+++ b/oneswap
@@ -75,6 +75,7 @@ CommandParser::CmdParser.new(ARGV) do
     ####################
     # Global Arguments #
     ####################
+    set :option, CommandParser::OPTIONS + OpenNebulaHelper::CLIENT_OPTIONS
 
     VCENTER = {
         :name  => 'vcenter',
@@ -302,6 +303,12 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    SKIP_CONTEXT = {
+        :name => 'skip_context',
+        :large => '--skip-context',
+        :description => 'Skips the injection of the context package'
+    }
+
     ESXI = {
         :name => 'esxi_ip',
         :large => '--esxi ip',
@@ -347,6 +354,7 @@ CommandParser::CmdParser.new(ARGV) do
     HYBRID = {
         :name => 'hybrid',
         :large => '--hybrid',
+        :description => 'Download the disk using rbvmomi2, then convert the vm using virt-v2v locally.'
     }
 
     WIN_GA = {
@@ -446,8 +454,6 @@ CommandParser::CmdParser.new(ARGV) do
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                    CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                    PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
-
-    set :option, CommandParser::OPTIONS + OpenNebulaHelper::CLIENT_OPTIONS
 
     ############################################################################
     # list resources

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -1,28 +1,48 @@
-#:vcenter:
-#:vuser:
-#:vpass:
-#:port:
-#:network:
-#:skip_ip:
-#:skip_mac:
-#:datastore:
-#:work_dir:
-#:format:
-#:delete:
-#:context:
-#:esxi_ip:
-#:esxi_user:
-#:esxi_pass:
-#:vddk_path:
-#:custom_convert:
-#:fallback:
-#:hybrid:
-#:qemu_ga_win:
-#:qemu_ga_linux:
-#:virtio_path:
-#:virt_tools:
-#:one_cluster:
-#:one_host:
-#:one_datastore:
-#:one_datastore_cluster:
-#:v2v_path:
+# OpenNebula Transfer Options, required for remote OpenNebula server
+#:http_transfer: false      # Enable HTTP transfer
+#:http_host: '192.168.0.10' # Hostname of this server
+#:http_port: 29869          # HTTP Port to transfer over
+
+# vCenter Authentication
+#:vcenter: '172.20.0.123'              # vCenter hostname or IP
+#:vuser: 'administrator@vsphere.local' # vCenter username
+#:vpass: 'changeme123'                 # vCenter password
+#:port: 443                            # vCenter port
+
+# ESXi Authentication
+#:esxi_ip: '172.20.0.123'  # ESXi hostname or IP
+#:esxi_user: 'root'        # ESXi username
+#:esxi_pass: 'changeme123' # ESXi password
+
+# Transfer Options
+#:custom_convert: # Uses OpenNebula's custom conversion process, useful for distributions which are not supported or fail to convert
+#:fallback:       # Fallback to OpenNebula's custom conversion process
+#:hybrid:         # Transfer using rbvmomi2's download, then convert with virt-v2v locally
+
+# NIC Options
+#:network: 1      # ID of the OpenNebula network
+#:skip_ip: false  # Do not create IP in OpenNebula network
+#:skip_mac: false # Do not create MAC in OpenNebula network
+
+# Datastore Options
+#:datastore: 1    # ID of the OpenNebula Image datastore
+
+# virt-v2v Options
+#:work_dir: '/tmp'                  # Directory where disk conversion takes place, will make subdir for each VM
+#:format: 'qcow2'                   # Disk format [ qcow2 | raw ]
+#:vddk_path:                        # Path to VDDK library
+#:qemu_ga_win:                      # Path to QEMU Guest Agent ISO for Windows
+#:qemu_ga_linux:                    # Install QEMU Guest Agent for Linux
+#:virtio_path:                      # Path to VirtIO drivers for Windows
+#:virt_tools: /usr/share/virt-tools # Path to the directory containing rhsrvany.exe
+#:v2v_path: 'virt-v2v'              # Path to virt-v2v
+
+# Extra Options
+#:delete: false                     # Delete the VM Disks after transfer
+#:context: '/var/lib/one/context/'  # Path to OpenNebula context packages
+
+# OpenNebula Placement Options
+#:one_cluster:           # ID of the OpenNebula Cluster
+#:one_host:              # ID of the OpenNebula Host
+#:one_datastore:         # ID of the OpenNebula System Datastore
+#:one_datastore_cluster: # ID of the OpenNebula Cluster for automatic Datastore assignment

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1129,12 +1129,36 @@ _EOF_"
             if guest_info
                 package_injection(d, guest_info)
             end
+            if @options[:http_transfer]
+                path = "http://#{@options[:http_host]}:#{@options[:http_port]}/#{File.basename(d)}"
+                server_thread = Thread.new do
+                    server = WEBrick::HTTPServer.new({
+                        Port: @options[:http_port],
+                        DocumentRoot: File.dirname(d),
+                        RequestCallback: ->(req, res) {
+                            res['Cache-Control'] = 'public, max-age=3600'
+                        },
+                        MaxThreads: 8,
+                    })
+
+                    trap('INT') { server.shutdown }
+
+                    server.start
+                end
+            else
+                path = d
+            end
             img.add_element('//IMAGE', {
                     'NAME' => "#{@options[:name]}_#{i}",
                     'TYPE' => guest_info ? 'OS' : 'DATABLOCK',
-                    'PATH' => "#{d}"
+                    'PATH' => "#{path}"
                 })
+            puts "Allocating image #{i} in OpenNebula"
             rc = img.allocate(img.to_xml, @options[:datastore])
+            if @options[:http_transfer]
+                server_thread.kill
+                server_thread.join
+            end
             if rc.class == OpenNebula::Error
                 puts 'Failed to create image. Image Definition:'.red
                 puts img.to_xml
@@ -1460,7 +1484,7 @@ _EOF_"
         format_list.show(list, options)
     end
 
-    # Show VM
+    # Convert VM
     #
     # @param options [Hash] User CLI Options
     def convert_vm

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1109,7 +1109,13 @@ _EOF_"
             print "\n#{prefixes[line_prefix]}"
             STDOUT.flush
           else
-            print '.' unless @dotskip
+            if !@dotskip
+                @last_dot_time ||= Time.now
+                if Time.now - @last_dot_time >= 0.1  # Check if 100ms have elapsed since the last dot
+                    print '.'
+                    @last_dot_time = Time.now
+                end
+            end
             LOGGER[:stderr].puts("#{Time.now.to_s[0...-6]} - #{line}") if DEBUG
           end
     end


### PR DESCRIPTION
More than just issue #8 (implement HTTP server to use a remote OpenNebula frontend) was resolved here, but I had found other smaller issues and after merging changes from https://github.com/OpenNebula/one-swap/pull/10 , there were some other useful changes as well.

Namely:

Skipping context injection entirely
Moved config file loading up before optional parameters
Expanded/explained configuration file
Fixed finding the VM path when there is no cluster, only Datacenter/ComputeResource/Host.
Fixed download VM disks with spaces in their names for custom/hybrid methods
Moving the HTTP Server killer down after the timeout that checks for image status
