### PR TITLE
B #26: fix virt tools path

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -380,7 +380,7 @@ CommandParser::CmdParser.new(ARGV) do
     RHSRVANY = {
         :name => 'virt_tools',
         :large => '--virt-tools /path/to/virt-tools',
-        :description => 'Path to the directory containing rhsrvany.exe, defaults to /usr/share/virt-tools. See https://github.com/rwmjones/rhsrvany.',
+        :description => 'Path to the directory containing rhsrvany.exe, defaults to /usr/local/share/virt-tools. See https://github.com/rwmjones/rhsrvany.',
         :format => String
     }
 
@@ -554,7 +554,7 @@ CommandParser::CmdParser.new(ARGV) do
             options[:context]       ||= '/var/lib/one/context/'
             options[:esxi_user]     ||= 'root'
             options[:datastore]     ||= 1
-            options[:virt_tools]    ||= '/usr/share/virt-tools'
+            options[:virt_tools]    ||= '/usr/local/share/virt-tools'
             options[:v2v_path]      ||= 'virt-v2v'
             options[:config_file]   ||= '/var/lib/one/oneswap.yaml'
 

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -29,14 +29,14 @@
 #:datastore: 1    # ID of the OpenNebula Image datastore
 
 # virt-v2v Options
-#:work_dir: '/tmp'                  # Directory where disk conversion takes place, will make subdir for each VM
-#:format: 'qcow2'                   # Disk format [ qcow2 | raw ]
-#:vddk_path:                        # Path to VDDK library
-#:qemu_ga_win:                      # Path to QEMU Guest Agent ISO for Windows
-#:qemu_ga_linux:                    # Install QEMU Guest Agent for Linux
-#:virtio_path:                      # Path to VirtIO drivers for Windows
-#:virt_tools: /usr/share/virt-tools # Path to the directory containing rhsrvany.exe
-#:v2v_path: 'virt-v2v'              # Path to virt-v2v
+#:work_dir: '/tmp'                        # Directory where disk conversion takes place, will make subdir for each VM
+#:format: 'qcow2'                         # Disk format [ qcow2 | raw ]
+#:vddk_path:                              # Path to VDDK library
+#:qemu_ga_win:                            # Path to QEMU Guest Agent ISO for Windows
+#:qemu_ga_linux:                          # Install QEMU Guest Agent for Linux
+#:virtio_path:                            # Path to VirtIO drivers for Windows
+#:virt_tools: /usr/local/share/virt-tools # Path to the directory containing rhsrvany.exe
+#:v2v_path: 'virt-v2v'                    # Path to virt-v2v
 
 # Extra Options
 #:delete: false                     # Delete the VM Disks after transfer


### PR DESCRIPTION
update virt-tools path to /usr/local/share/virt-tools, latest versions of virt-v2v use this instead. Mentioned in the docs about using older versions and making symlinks.