### PR TITLE
B #28: fix variable name causing error in networks

### DIFF
--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1475,7 +1475,7 @@ _EOF_"
                 
                 #vm_template.add_element('//VMTEMPLATE', net_templ)
             end
-        elsif vc_nets.length > 0
+        elsif vc_nics.length > 0
             puts "You will need to create NICs and assign networks in the VM Template in OpenNebula manually."
         end
         vm_template


### PR DESCRIPTION
vc_nets -> vc_nics

must have been a typo long ago that didn't get triggered in a long while.