### PR TITLE
F OpenNebula/one-swap#40: Multiple NICs and DS

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -148,7 +148,7 @@ CommandParser::CmdParser.new(ARGV) do
         :name => 'network',
         :large => '--network id',
         :description => 'If a VCENTER_NETWORK_MATCH attribute in an OpenNebula does not match the name of a vCenter network, assign to this OpenNebula Network ID instead.',
-        :format => Integer
+        :format => String
     }
 
     NO_IP = {
@@ -270,7 +270,7 @@ CommandParser::CmdParser.new(ARGV) do
         :name => 'datastore',
         :large => '--datastore id',
         :description => 'Create images in the Image Datastore with this ID, Default: 1',
-        :format => Integer
+        :format => String
     }
 
     WORK_DIR = {


### PR DESCRIPTION
- Allow assigning different VNET IDs when a VM has multiple NICs. The parameter --network accepts a comma separated list of VNET IDs so they will be assigned sequentially
- Allow assigning different DS IDs when a VM has multiple disks. The parameter --datastore accepts a comma separated list of DS IDs so each disk will be allocated in a different Datastore sequentially