### PR TITLE
F OpenNebula/one-swap#35: Clone VM before converting to leave it online

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -465,13 +465,7 @@ CommandParser::CmdParser.new(ARGV) do
         :large => '--clone',
         :description => 'Trigger a VM full clone and convert that clone without requiring to poweroff the original VM',
     }
-
-    CLONE = {
-        :name => 'clone',
-        :large => '--clone',
-        :description => 'Trigger a VM full clone and convert that clone without requiring to poweroff the original VM',
-    }
-
+    
     REMOVEVMTOOLS = {
         :name => 'remove_vmtools',
         :large => '--remove_vmtools',
@@ -592,7 +586,6 @@ CommandParser::CmdParser.new(ARGV) do
             options[:v2v_path]       ||= 'virt-v2v'
             options[:remove_vmtools] ||= false
             options[:clone]          ||= false
-
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect { |addrinfo| addrinfo.ipv4? && !addrinfo.ipv4_loopback? }&.ip_address

--- a/oneswap
+++ b/oneswap
@@ -463,8 +463,7 @@ CommandParser::CmdParser.new(ARGV) do
     CLONE = {
         :name => 'clone',
         :large => '--clone',
-        :description => 'Trigger a VM clone and convert that clone without requiring to poweroff the original VM',
-        :format      => [TrueClass, FalseClass]
+        :description => 'Trigger a VM full clone and convert that clone without requiring to poweroff the original VM',
     }
 
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]

--- a/oneswap
+++ b/oneswap
@@ -583,13 +583,15 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:fallback] && options[:custom_convert]
                 raise "Cannot define both --fallback and --custom."
             end
-            options[:work_dir]      ||= '/tmp'
-            options[:format]        ||= 'qcow2'
-            options[:context]       ||= '/usr/share/one/context'
-            options[:esxi_user]     ||= 'root'
-            options[:datastore]     ||= 1
-            options[:virt_tools]    ||= '/usr/local/share/virt-tools'
-            options[:v2v_path]      ||= 'virt-v2v'
+            options[:work_dir]       ||= '/tmp'
+            options[:format]         ||= 'qcow2'
+            options[:context]        ||= '/usr/share/one/context'
+            options[:esxi_user]      ||= 'root'
+            options[:datastore]      ||= 1
+            options[:virt_tools]     ||= '/usr/local/share/virt-tools'
+            options[:v2v_path]       ||= 'virt-v2v'
+            options[:remove_vmtools] ||= false
+            options[:clone]          ||= false
 
 
             if options[:http_transfer]

--- a/oneswap
+++ b/oneswap
@@ -460,6 +460,13 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    CLONE = {
+        :name => 'clone',
+        :large => '--clone',
+        :description => 'Trigger a VM clone and convert that clone without requiring to poweroff the original VM',
+        :format      => [TrueClass, FalseClass]
+    }
+
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
@@ -467,7 +474,7 @@ CommandParser::CmdParser.new(ARGV) do
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE] + AUTH_OPTS
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                    CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
-                   PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
+                   PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
     IMPORT_OPTS = [OVA, DATASTORE, NETWORK] + V2V_OPTS
 
     ############################################################################
@@ -572,7 +579,7 @@ CommandParser::CmdParser.new(ARGV) do
             options[:datastore]     ||= 1
             options[:virt_tools]    ||= '/usr/local/share/virt-tools'
             options[:v2v_path]      ||= 'virt-v2v'
-
+            options[:clone]         ||= false
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect { |addrinfo| addrinfo.ipv4? && !addrinfo.ipv4_loopback? }&.ip_address

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -23,6 +23,9 @@
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files
 
+# Convert Options
+#:clone: false                            # Trigger a VM full clone and convert that clone without requiring to poweroff the original VM
+
 # NIC Options
 #:network: 1                              # ID of the OpenNebula network
 #:skip_ip: false                          # Do not create IP in OpenNebula network

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -639,7 +639,7 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
 
     def create_base_template
         vm_template_config = {
-            "NAME" => "#{@props['name']}",
+            "NAME" => "#{@options[:name]}",
             "CPU"  => "#{@props['config'][:hardware][:numCPU]}",
             "vCPU" => "#{@props['config'][:hardware][:numCPU]}",
             "MEMORY" => "#{@props['config'][:hardware][:memoryMB]}",
@@ -2238,7 +2238,7 @@ _EOF_"
             begin
                 delete_vm(cloned_vm)
             rescue RbVmomi::Fault => e
-                raise "Failed to delete VM #{@options[:name]}: #{e.message}"
+                puts "Failed to delete cloned VM #{@options[:name]}: #{e.message}, remove the cloned VM manually."
             end
         end
 

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2261,5 +2261,4 @@ _EOF_"
             puts "\nVM Template:\n#{vm_template.to_xml}\n"
         end
     end
-
 end


### PR DESCRIPTION
Only change "outside the scope" of the clone functionality is the value used on the VM Template name, using #{@options[:name]} (input VM name) instead of #{@props['name']} (retrieved VM name), to avoid the template be named with the "-clone" extension used as name for the cloned VM.

As my understand, the name should be the same and shouldn't affect the rest of the cases (some tests done).
