### PR TITLE
F OpenNebula/one-swap#41: Import VMDK files as images

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -453,6 +453,13 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    VMDK = {
+        :name => 'vmdk',
+        :large => '--vmdk vmdk.vmdk',
+        :description => 'File name or path to VMDK files folder in case the guest was exported as a "Folder of files" or if the VMDK has been previously unpacked',
+        :format => String
+    }
+
     ROOT = {
         :name => 'root',
         :large => '--root option',
@@ -474,7 +481,7 @@ CommandParser::CmdParser.new(ARGV) do
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                    CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                    PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, REMOVEVMTOOLS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
-    IMPORT_OPTS = [OVA, DATASTORE, NETWORK] + V2V_OPTS
+    IMPORT_OPTS = [OVA, VMDK, DATASTORE, NETWORK, SKIP_CONTEXT] + V2V_OPTS
 
     ############################################################################
     # list resources
@@ -602,7 +609,7 @@ CommandParser::CmdParser.new(ARGV) do
     end
 
     import_desc = <<-EOT.unindent
-        Import an OVA file exported from VMware
+        Import an OVA/VMDK file exported from VMware
 
         Examples:
            - import from an OVA file:
@@ -612,6 +619,10 @@ CommandParser::CmdParser.new(ARGV) do
            - import from an OVF file:
 
              oneswap import --ova /path/to/files
+
+            - import from an VMDK file:
+
+             oneswap import --vmdk /path/to/files
     EOT
 
     command :import, import_desc, :options => IMPORT_OPTS do

--- a/oneswap
+++ b/oneswap
@@ -456,7 +456,7 @@ CommandParser::CmdParser.new(ARGV) do
     VMDK = {
         :name => 'vmdk',
         :large => '--vmdk vmdk.vmdk',
-        :description => 'File name or path to VMDK files folder in case the guest was exported as a "Folder of files" or if the VMDK has been previously unpacked',
+        :description => 'Full VMDK file path to import.',
         :format => String
     }
 
@@ -609,20 +609,20 @@ CommandParser::CmdParser.new(ARGV) do
     end
 
     import_desc = <<-EOT.unindent
-        Import an OVA/VMDK file exported from VMware
+        Import an OVA as VM or VMDK as Image file exported from VMware
 
         Examples:
-           - import from an OVA file:
+           - import VM from an OVA file:
 
              oneswap import --ova OVA.ova
 
-           - import from an OVF file:
+           - import VM from an OVF file:
 
              oneswap import --ova /path/to/files
 
-            - import from an VMDK file:
+            - import Image from an VMDK file:
 
-             oneswap import --vmdk /path/to/files
+             oneswap import --vmdk disk.vmdk
     EOT
 
     command :import, import_desc, :options => IMPORT_OPTS do

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2146,7 +2146,6 @@ _EOF_"
         print "Allocating the Image => "
         img_ids = create_one_images([img_loc])
         puts img_ids.nil? || img_ids.first[:id].nil? ? "No Image reported being created".red : "Created image: #{img_ids.first[:id]}".green
-
     end
 
     # Convert VM

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2132,7 +2132,7 @@ _EOF_"
         end
     end
 
-    # Import Imagee
+    # Import Image
     #
     # @param options [Hash] User CLI Options
     #

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1420,6 +1420,26 @@ _EOF_"
         end
     end
 
+    # Create and run the qemu-img vmdk conversion
+    # This uses qemu-img to convert an vmdk image to desired format (Default: qcow2).
+    # Outputs a converted image location if success
+    def convert_vmdk(vmdk_path, output_format: 'qcow2')
+        raise "Input file not found: #{vmdk_path}" unless File.exist?(vmdk_path)
+        puts "Converting disk #{vmdk_path} to #{output_format}..."
+        base_name = File.basename(vmdk_path, '.vmdk')
+        output_path = File.join(@options[:work_dir], 'conversions', "#{base_name}.#{output_format}")
+        command = "qemu-img convert -O #{output_format} -p -S 4k -W #{vmdk_path} #{output_path}"
+        t0 = Time.now
+        success = system(command)
+        duration = (Time.now - t0).round(2)
+        if success
+          puts "Disk converted successfully in #{duration} seconds."
+          return output_path
+        else
+          raise "Failed to convert #{vmdk_path} to #{output_format}"
+        end
+    end
+
     def handle_v2v_error(line)
         LOGGER[:stderr].puts("#{Time.now.to_s[0...-6]} - #{line}") if DEBUG
         pass_list  = [
@@ -1932,7 +1952,8 @@ _EOF_"
     # @param name    [Hash] Object Name
     # @param options [Hash] User CLI options
     def import(options)
-        name = File.basename(options[:ova], '.ova')
+        source = options[:ova] || options[:vmdk]
+        name = File.basename(source, File.extname(source))
         check_one_connectivity
         if !Dir.exist?(options[:work_dir])
             raise 'Provided working directory '\
@@ -1948,7 +1969,11 @@ _EOF_"
             Dir.mkdir(conv_path) if !Dir.exist?(conv_path)
             Dir.mkdir(tran_path) if !Dir.exist?(tran_path)
 
-            import_vm
+            if options[:vmdk]
+                import_image
+            else
+                import_vm
+            end
         ensure
             cleanup_all
         end
@@ -2105,6 +2130,23 @@ _EOF_"
             puts 'Failed'.red
             puts "\nVM Template:\n#{vm_template.to_xml}\n"
         end
+    end
+
+    # Import Imagee
+    #
+    # @param options [Hash] User CLI Options
+    #
+    def import_image
+        # Convert VMDK to QCOW2 compatible
+        print "Converting the Image => "
+        img_loc = convert_vmdk(@options[:vmdk])
+        puts img_loc.nil? ? "No Image reported being converted".red : "Converted image: #{img_loc}".green
+
+        # Import Image to OpenNebula
+        print "Allocating the Image => "
+        img_ids = create_one_images([img_loc])
+        puts img_ids.nil? || img_ids.first[:id].nil? ? "No Image reported being created".red : "Created image: #{img_ids.first[:id]}".green
+
     end
 
     # Convert VM


### PR DESCRIPTION
By default context injection is done, to skip context we will reuse the "`--skip-context` that  already exists on the code.