### PR TITLE
M #-: Download srvany with vendor script and install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,9 +79,10 @@ fi
 
 LIB_DIRS="$LIB_LOCATION/ruby/cli/one_helper"
 MAN_LOCATION="/usr/share/man/man1"
+VIRTTOOLS_LOCATION="/usr/share/virt-tools"
 
 MAKE_DIRS="$BIN_LOCATION $SHARE_LOCATION $LIB_LOCATION $ETC_LOCATION
-           $VAR_LOCATION $LIB_DIRS $SCRIPTS_LOCATION"
+           $VAR_LOCATION $LIB_DIRS $SCRIPTS_LOCATION $VIRTTOOLS_LOCATION"
 
 #-------------------------------------------------------------------------------
 # FILE DEFINITION, WHAT IS GOING TO BE INSTALLED AND WHERE
@@ -91,6 +92,7 @@ INSTALL_FILES=(
 	ONE_CLI_LIB_FILES:$LIB_LOCATION/ruby/cli/one_helper
     CONF_FILES:$ETC_LOCATION
     SCRIPTS_FILES:$SCRIPTS_LOCATION
+    EXE_FILES:$VIRTTOOLS_LOCATION
 )
 
 
@@ -98,6 +100,7 @@ BIN_FILES="oneswap"
 ONE_CLI_LIB_FILES="oneswap_helper.rb"
 CONF_FILES="oneswap.yaml"
 SCRIPTS_FILES="scripts/*"
+EXE_FILES="vendor/exe/*"
 
 #-----------------------------------------------------------------------------
 # INSTALL.SH SCRIPT

--- a/vendor/download
+++ b/vendor/download
@@ -17,7 +17,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-which wget rpm2cpio cpio 1>/dev/null
+which wget rpm2cpio cpio dirname realpath xargs 1>/dev/null
 
 readonly SELF=$(realpath "$0" | xargs dirname) && cd "$SELF/"
 

--- a/vendor/download
+++ b/vendor/download
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2025, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+# -------------------------------------------------------------------------- #
+
+set -o errexit -o nounset -o pipefail
+
+which wget rpm2cpio cpio 1>/dev/null
+
+readonly SELF=$(realpath "$0" | xargs dirname) && cd "$SELF/"
+
+readonly SRVANY_URL="https://kojipkgs.fedoraproject.org//packages/mingw-srvany/1.1/4.fc38/noarch/mingw32-srvany-1.1-4.fc38.noarch.rpm"
+
+wget -nd -O srvany.rpm $SRVANY_URL && rpm2cpio srvany.rpm | cpio -idmv
+
+install -d "$SELF/exe/"
+
+mv $SELF/usr/i686-w64-mingw32/sys-root/mingw/bin/*exe $SELF/exe/
+rm -rf $SELF/srvany.rpm $SELF/usr


### PR DESCRIPTION
- Create vendor/download script to download and extract exe files for srvany.
- Add exe files to install script, put them under /usr/share/virt-tools