### PR TITLE
F OpenNebula/one#7475 Assign user/group from parameter

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -526,6 +526,20 @@ CommandParser::CmdParser.new(ARGV) do
 
     }
 
+    ONE_USER = {
+        :name => 'one_user',
+        :large => '--one-user user',
+        :description => 'Assign migrated objects (images, VM template) to this OpenNebula user (name or numeric ID)',
+        :format => String
+    }
+
+    ONE_GROUP = {
+        :name => 'one_group',
+        :large => '--one-group group',
+        :description => 'Assign migrated objects (images, VM template) to this OpenNebula group (name or numeric ID)',
+        :format => String
+    }
+
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
@@ -534,9 +548,9 @@ CommandParser::CmdParser.new(ARGV) do
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
-                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, ACCEPT_CERT] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
+                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, ACCEPT_CERT, ONE_USER, ONE_GROUP] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
     IMPORT_OPTS = [OVA, VMDK, DATASTORE, NETWORK, SKIP_CONTEXT, REMOVE_VMTOOLS, UEFI_PATH,
-                   UEFI_SEC_PATH, INJECT_DNS] + V2V_OPTS
+                   UEFI_SEC_PATH, INJECT_DNS, ONE_USER, ONE_GROUP] + V2V_OPTS
 
     ############################################################################
     # list resources

--- a/oneswap.1
+++ b/oneswap.1
@@ -88,8 +88,12 @@
                            instead\.
  \-\-one\-cluster id          ID of the Cluster in OpenNebula the VM Template
                            should be scheduled to
+ \-\-one\-group group         Assign migrated objects (images, VM template) to
+                           this OpenNebula group (name or numeric ID)\.
  \-\-one\-sys\-ds id           ID of the System Datastore in OpenNebula the VM
                            should be scheduled to
+ \-\-one\-user user           Assign migrated objects (images, VM template) to
+                           this OpenNebula user (name or numeric ID)\.
  \-\-one\-ds\-cluster id       ID of the Cluster in OpenNebula the System
                            Datastore should be scheduled to
  \-\-one\-host id             ID of the Host in OpenNebula the VM Template

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -59,6 +59,10 @@
 #:one_datastore:                          # ID of the OpenNebula System Datastore
 #:one_datastore_cluster:                  # ID of the OpenNebula Cluster for automatic Datastore assignment
 
+# OpenNebula Ownership Options
+#:one_user:                               # Assign migrated objects to this OpenNebula user (name or numeric ID)
+#:one_group:                              # Assign migrated objects to this OpenNebula group (name or numeric ID)
+
 # Extra VM Options:
 #:dev_prefix:                             # Device prefix for the VM disks ex: sd, hd, vd
 #:cpu_model:                              # CPU model

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1923,6 +1923,8 @@ _EOF_"
                 next
             end
 
+            chown_one_object(img, *resolve_one_ownership)
+
             img_wait_sec = @options[:img_wait] || 120
             puts 'Waiting for image to be ready. Timeout: ' + img_wait_sec.to_s + ' seconds.'
 
@@ -2519,6 +2521,7 @@ _EOF_"
         if rc.nil?
             puts 'Success'.green
             puts "VM Template ID: #{vm_template.id}\n"
+            chown_one_object(vm_template, *resolve_one_ownership)
         else
             puts 'Failed'.red
             puts "\nVM Template:\n#{vm_template.to_xml}\n"
@@ -2672,6 +2675,7 @@ _EOF_"
         if rc.nil?
             puts 'Success'.green
             puts "VM Template ID: #{vm_template.id}\n"
+            chown_one_object(vm_template, *resolve_one_ownership)
         else
             puts 'Failed'.red
             puts "\nVM Template:\n#{vm_template.to_xml}\n"
@@ -2721,6 +2725,84 @@ _EOF_"
     end
 
     private
+
+    # Resolves :one_user and :one_group options to OpenNebula numeric IDs.
+    # Accepts either a numeric string/integer (used directly) or a name
+    # (looked up via the UserPool / GroupPool). Returns [-1, -1] when neither
+    # option is set, which tells chown to leave the current owner unchanged.
+    # Result is memoised so pool lookups only happen once per invocation.
+    #
+    # @return [Array(Integer, Integer)] [uid, gid]
+    def resolve_one_ownership
+        @resolved_ownership ||= begin
+            uid = -1
+            gid = -1
+
+            if @options[:one_user]
+                val = @options[:one_user].to_s
+                if val =~ /^\d+$/
+                    uid = val.to_i
+                else
+                    pool = OpenNebula::UserPool.new(@client)
+                    rc   = pool.info_all
+                    if rc.class == OpenNebula::Error
+                        puts "Failed to fetch user pool: #{rc.message}".red
+                    else
+                        found = pool.find {|u| u['NAME'] == val }
+                        if found
+                            uid = found['ID'].to_i
+                        else
+                            puts "OpenNebula user '#{val}' not found, skipping user ownership assignment.".brown
+                        end
+                    end
+                end
+            end
+
+            if @options[:one_group]
+                val = @options[:one_group].to_s
+                if val =~ /^\d+$/
+                    gid = val.to_i
+                else
+                    pool = OpenNebula::GroupPool.new(@client)
+                    rc   = pool.info_all
+                    if rc.class == OpenNebula::Error
+                        puts "Failed to fetch group pool: #{rc.message}".red
+                    else
+                        found = pool.find {|g| g['NAME'] == val }
+                        if found
+                            gid = found['ID'].to_i
+                        else
+                            puts "OpenNebula group '#{val}' not found, skipping group ownership assignment.".brown
+                        end
+                    end
+                end
+            end
+
+            [uid, gid]
+        end
+    end
+
+    # Changes ownership of an OpenNebula object.
+    # Pass uid/gid as -1 to leave the corresponding value unchanged.
+    #
+    # @param obj [OpenNebula::Image, OpenNebula::Template] object to chown
+    # @param uid [Integer] target user ID  (-1 = keep current)
+    # @param gid [Integer] target group ID (-1 = keep current)
+    def chown_one_object(obj, uid, gid)
+        return if uid == -1 && gid == -1
+
+        rc = obj.chown(uid, gid)
+        obj_type = obj.class.name.split('::').last
+        if rc.class == OpenNebula::Error
+            puts "Failed to change ownership of #{obj_type} #{obj.id}: #{rc.message}".red
+        else
+            owner_str = uid != -1 ? "user #{@options[:one_user]}(#{uid})" : nil
+            group_str = gid != -1 ? "group #{@options[:one_group]}(#{gid})" : nil
+            label = [owner_str, group_str].compact.join(' and ')
+            puts "#{obj_type} #{obj.id} assigned to #{label}".green
+            @logger.info "Changed ownership of #{obj_type} #{obj.id} to uid #{uid} gid #{gid}"
+        end
+    end
 
     def execute_command(cmd)
         @logger.info "Running command #{cmd}"


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
After migrating a VM the created images and VM template can now be automatically assigned to a specific OpenNebula user and/or group.

Two new options are available on both convert and import commands:
```
--one-user - accepts a username or numeric ID
--one-group - accepts a group name or numeric ID
```
Both can also be set in oneswap.yaml via `one_user` and `one_group` variables.

Once configured a message is printed to the terminal:
```
VM Template ID: 197
Template 197 assigned to user 5(5) and group 100(100)
```
Example run:
```
root@blackberry:~# oneswap convert "oneswap"
Running OpenNebula prechecks...
Certificate thumbprint: 09:77:5b:0e:94:b0:81:ae:9e:a6:c6:a3:51:01:34:58:20:b2:24:b0
Running: virt-v2v -v --machine-readable -ic 'vpx://oneswap%40vsphere.local@xxx/Datacenter/Cluster/yyy?no_verify=1' -ip /var/tmp/oneswap/vpassfile -it vddk -io vddk-libdir=/opt/vmware-vix-disklib-distrib/ -io vddk-thumbprint=09:77:5b:0e:94:b0:81:ae:9e:a6:c6:a3:51:01:34:58:20:b2:24:b0 -o local -os /var/tmp/oneswap/conversions/ -of qcow2 'oneswap'

Setting up the source: -i libvirt -ic vpx://oneswap%40vsphere.local@xxx/Datacenter/Cluster/yyy?no_verify=1 -it vddk oneswap..
Opening the source...................
Inspecting the source
Inspecting guest OS........................
Checking for sufficient free disk space in the guest
Gathering mountpoint stats and converting guest
Converting Ubuntu 24.04 LTS to run on KVM, this may take a long time....
could not determine a way to update the configuration of Grub2.......
The QEMU Guest Agent will be installed for this guest at first boot.....................................................................................................................................................................................................................................................................................................................................................................................................................................
This guest has virtio drivers installed.
Mapping filesystem data to avoid copying unused and blank areas
Inspecting filesystems, this can take several minutes....
Closing the overlay.
Assigning disks to buses
Checking if the guest needs BIOS or UEFI to boot.
This guest requires UEFI on the target to boot.
Setting up the destination: -o disk -os /var/tmp/oneswap/conversions/........
Copying disk 1/1, this may take a long time

Creating output metadata
Finishing off
1 disks on the local disk for this VM: ["/var/tmp/oneswap/conversions/oneswap-sda"]
Creating Images in OpenNebula
Inspecting disk...Done (1.71s)
Injecting one-context...Running: virt-customize -q -a /var/tmp/oneswap/conversions/oneswap-sda --uninstall cloud-init --copy-in /usr/share/one/context/one-context_7.0.0-0.deb:/tmp --install /tmp/one-context_7.0.0-0.deb --delete /tmp/one-context_7.0.0-0.deb --run-command 'systemctl enable network.service || exit 0'
Success (20.03s)
Allocating image 0 in OpenNebula
Image 51 assigned to user 5(5) and group 100(100)
Waiting for image to be ready. Timeout: 120 seconds.
Allocated images in OpenNebula in (27.35s)
Created images: [{:id=>51, :os=>"linux"}]
Adding 1 NICs, assigning networks from 142
Skipping MAC address for NIC#0
No VCENTER_NETWORK_MATCH found for 'vms'. Using assigned network: 142
Found network 'vms' but no guest network information. Adding blank NIC.
Allocating the VM template...Success
VM Template ID: 197
Template 197 assigned to user 5(5) and group 100(100)
Deleting password files.
Deleting vdisks in /var/tmp/oneswap/conversions
Deleting everything in and including /var/tmp/oneswap
```

Expected output:
```
root@blackberry:~# onetemplate show 197
TEMPLATE 197 INFORMATION
ID             : 197
NAME           : oneswap
USER           : test_regular
GROUP          : Test Group regular
LOCK           : None
REGISTER TIME  : 03/25 10:48:40

PERMISSIONS
OWNER          : um-
GROUP          : ---
OTHER          : ---

TEMPLATE CONTENTS
CONTEXT=[
  NETWORK="YES",
  SSH_PUBLIC_KEY="$USER[SSH_PUBLIC_KEY]" ]
CPU="2"
DESCRIPTION="Ubuntu 24.04"
DISK=[
  IMAGE_ID="51" ]
GRAPHICS=[
  LISTEN="0.0.0.0",
  TYPE="VNC" ]
HYPERVISOR="kvm"
LOGO="images/logos/ubuntu.png"
MEMORY="2048"
NIC=[
  NETWORK_ID="142" ]
OS=[
  FIRMWARE="/usr/share/OVMF/OVMF_CODE_4M.fd",
  MACHINE="q35" ]
VCPU="2"
```
### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.0

<hr>

- [ ] Check this if this PR should **not** be squashed
