### PR TITLE
F #814: Remove vmware tools from a Windows Server 2025

### DIFF
--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -19,6 +19,7 @@ require 'opennebula'
 require 'logger'
 require 'fileutils'
 require 'shellwords'
+require 'tempfile'
 require 'tmpdir'
 require_relative 'vsphere_client'
 require_relative 'esxi_vm'
@@ -2188,7 +2189,171 @@ _EOF_"
         vm_template
     end
 
+    # Disable VMware Tools services in the offline Windows registry so they
+    # never start during the first boot (which trigger the error dialog
+    # before the firstboot cleanup script runs).
+    VMTOOLS_SERVICES_TO_DISABLE = %w[VMTools VGAuthService].freeze
+    VMTOOLS_CONTROL_SETS = %w[ControlSet001 ControlSet002].freeze
+
+    def windows_control_sets_for_disk(disk)
+        cmd = "virt-win-reg #{disk} 'HKLM\\SYSTEM\\Select'"
+        stdout, stderr, status = Open3.capture3(cmd)
+
+        unless status.success?
+            @logger.warn("Could not read HKLM\\SYSTEM\\Select, using fallback control sets: #{stderr.to_s.strip}")
+            return VMTOOLS_CONTROL_SETS
+        end
+
+        sets = stdout.each_line.filter_map do |line|
+            match = line.match(/^"(Current|Default|LastKnownGood)"=dword:([0-9a-fA-F]+)/)
+            next unless match
+
+            index = match[2].to_i(16)
+            next if index <= 0
+
+            format('ControlSet%03d', index)
+        end
+
+        sets = (sets + ['ControlSet001']).uniq
+        @logger.info("Detected control sets for offline service disable: #{sets.join(', ')}")
+        sets
+    end
+
+    def disable_vmtools_services_offline(disk)
+        puts 'Disabling VMware Tools services in offline registry...'
+        @logger.info('Attempting to disable VMware Tools services offline')
+
+        # Try virt-win-reg first
+        @logger.info('Trying virt-win-reg method...')
+        if disable_vmtools_via_virt_win_reg(disk)
+            @logger.info('Successfully disabled services via virt-win-reg')
+            puts 'VMware Tools services disabled (virt-win-reg)'.green
+            return
+        end
+
+        # Fall back to guestfish
+        @logger.info('virt-win-reg failed or not available, falling back to guestfish')
+        puts 'virt-win-reg failed, trying guestfish...'.brown
+        unless disable_vmtools_via_guestfish(disk)
+            @logger.warn('Both virt-win-reg and guestfish failed to disable services')
+            puts 'Warning: could not disable VMware Tools services offline. ' \
+                 'The error dialog may still appear on first boot.'.brown
+            return false
+        end
+        @logger.info('Successfully disabled services via guestfish')
+        puts 'VMware Tools services disabled (guestfish)'.green
+    end
+
+    def disable_vmtools_via_virt_win_reg(disk)
+        control_sets = windows_control_sets_for_disk(disk)
+        applied_sets = []
+
+        control_sets.each do |control_set|
+            reg_entries = VMTOOLS_SERVICES_TO_DISABLE.map do |svc|
+                "[HKEY_LOCAL_MACHINE\\SYSTEM\\#{control_set}\\Services\\#{svc}]\n" \
+                "\"Start\"=dword:00000004\n"
+            end.join("\n")
+
+            reg_content = "Windows Registry Editor Version 5.00\n\n#{reg_entries}"
+
+            Tempfile.create(['disable_vmtools', '.reg']) do |f|
+                f.write(reg_content)
+                f.flush
+
+                @logger.debug("Registry file content for #{control_set}:\n#{reg_content}")
+                @logger.info("Running virt-win-reg for #{control_set}: #{VMTOOLS_SERVICES_TO_DISABLE.join(', ')}")
+
+                cmd = "virt-win-reg --merge #{disk} #{Shellwords.escape(f.path)}"
+                @logger.debug("virt-win-reg command: #{cmd}")
+
+                stdout, stderr, status = Open3.capture3(cmd)
+
+                @logger.debug("virt-win-reg stdout (#{control_set}): #{stdout}")
+                @logger.debug("virt-win-reg stderr (#{control_set}): #{stderr}")
+                @logger.debug("virt-win-reg exit code (#{control_set}): #{status.exitstatus}")
+
+                if status.success?
+                    applied_sets << control_set
+                else
+                    error_msg = stderr.to_s.strip.empty? ? stdout.to_s.strip : stderr.to_s.strip
+                    @logger.warn("virt-win-reg failed for #{control_set} with exit code #{status.exitstatus}: #{error_msg}")
+                    puts "  virt-win-reg error for #{control_set} (exit #{status.exitstatus}): #{error_msg}".brown if error_msg
+                end
+            end
+        end
+
+        if applied_sets.empty?
+            false
+        else
+            @logger.info("VMware Tools services disabled via virt-win-reg for: #{applied_sets.join(', ')}")
+            true
+        end
+    end
+
+    def disable_vmtools_via_guestfish(disk)
+        @logger.info("Attempting to disable services via guestfish + hivexregedit")
+        control_sets = windows_control_sets_for_disk(disk)
+        
+        guestfish_script = <<-GUESTFISH
+add #{disk}
+run
+GUESTFISH
+
+        control_sets.product(VMTOOLS_SERVICES_TO_DISABLE).each do |control_set, svc|
+            guestfish_script += "download /Windows/System32/config/SYSTEM /tmp/SYSTEM_orig\n"
+            guestfish_script += "! hivexregedit --merge /tmp/SYSTEM_orig HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\#{control_set}\\\\Services\\\\#{svc} Start dword 0x00000004\n"
+            guestfish_script += "upload /tmp/SYSTEM_orig /Windows/System32/config/SYSTEM\n"
+        end
+
+        @logger.debug("Guestfish script:\n#{guestfish_script}")
+
+        Tempfile.create(['disable_vmtools', '.gf']) do |f|
+            f.write(guestfish_script)
+            f.flush
+            
+            cmd = "guestfish -f #{Shellwords.escape(f.path)}"
+            @logger.info("Running guestfish + hivexregedit to disable services: #{VMTOOLS_SERVICES_TO_DISABLE.join(', ')}")
+            @logger.debug("guestfish command: #{cmd}")
+            
+            stdout, stderr, status = Open3.capture3(cmd)
+            
+            @logger.debug("guestfish output: #{stdout}")
+            @logger.debug("guestfish stderr: #{stderr}")
+            @logger.debug("guestfish exit code: #{status.exitstatus}")
+            
+            if status.success?
+                @logger.info('VMware Tools services disabled via guestfish + hivexregedit')
+                return true
+            else
+                error_msg = stderr.to_s.strip.empty? ? stdout.to_s.strip : stderr.to_s.strip
+                error_msg = 'Unknown guestfish error' if error_msg.to_s.strip.empty?
+                @logger.warn("guestfish failed with exit code #{status.exitstatus}: #{error_msg}")
+                puts "  guestfish error (exit #{status.exitstatus}): #{error_msg}".brown if error_msg
+                return false
+            end
+        end
+    end
+
     # Remove VMWare Tools injection from the VM
+    def remove_vmtools_command(disk, osinfo, script_path)
+        if osinfo['name'] == 'windows'
+            script_name = File.basename(script_path)
+            real_script_path = File.realpath(script_path)
+            # Disable VMware services on first boot (before they start)
+            # Prevent error dialog box from appearing
+            disable_svc_cmd = 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ' \
+                '"sc config VMTools start=disabled; sc config VGAuthService start=disabled; sc stop VMTools; sc stop VGAuthService" 2>$null'
+            
+            'virt-customize -q -a ' + disk +
+            ' --mkdir /Temp' +
+            " --copy-in #{Shellwords.escape(real_script_path)}:/Temp" +
+            " --firstboot-command '#{disable_svc_cmd}'" +
+            " --firstboot-command 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\\Temp\\#{script_name}'"
+        else
+            "virt-customize -q -a #{disk} --firstboot '#{script_path}'"
+        end
+    end
+
     def remove_vmtools_injection(disk, osinfo)
         return unless @options[:remove_vmtools]
 
@@ -2203,13 +2368,14 @@ _EOF_"
             puts 'Unable to find vmware_tools_removal script, please remove VMWare Tools manually.'
             return
         end
-        cmd = "virt-customize -q -a #{disk} --firstboot '#{script_path}'"
+        cmd = remove_vmtools_command(disk, osinfo, script_path)
         _stdout, status = run_cmd_report(cmd, true)
         if !status.success?
             puts 'Remove VMWare tools injection failed somehow, please remove VMWare Tools manually.'
             return
         end
-        puts 'VMware Tools removal injection completed. The script will run on the first boot.'.green
+        disable_vmtools_services_offline(disk) if osinfo['name'] == 'windows'
+        puts 'VMware Tools removal script staged for first boot. Check the guest log if removal fails.'.green
     end
 
     # Run a OpenNebula system prechecks:

--- a/scripts/vmware_tools_removal.ps1
+++ b/scripts/vmware_tools_removal.ps1
@@ -1,107 +1,231 @@
 
-# Script to remove VMware Tools from Windows machines (Windows 2008–2019)
+# Script to remove VMware Tools from Windows machines (Windows 2008-2019)
 
-function Get-VMwareToolsInstallerID {
-    foreach ($item in $(Get-ChildItem Registry::HKEY_CLASSES_ROOT\Installer\Products)) {
-        if ($item.GetValue('ProductName') -eq 'VMware Tools') {
-            return @{
-                reg_id = $item.PSChildName
-                msi_id = [Regex]::Match($item.GetValue('ProductIcon'), '(?<={)(.*?)(?=})') | Select-Object -ExpandProperty Value
-            }
+$script:LogFile = 'C:\Program Files\Guestfs\Firstboot\vmware_tools_removal.log'
+
+function Write-RemovalLog {
+    param(
+        [string]$Message
+    )
+
+    $line = "[VMWare Tools removal] $Message"
+    Write-Host $line
+    try {
+        $log_dir = Split-Path -Parent $script:LogFile
+        New-Item -ItemType Directory -Path $log_dir -Force | Out-Null
+        Add-Content -Path $script:LogFile -Value "$(Get-Date -Format o) $line"
+    } catch {
+        Write-Host "[VMWare Tools removal] Warning: could not write log file: $_"
+    }
+}
+
+function Get-VMwareToolsInstallerEntry {
+    $uninstall_roots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    foreach ($root in $uninstall_roots) {
+        $entry = Get-ItemProperty $root -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -eq 'VMware Tools' -or $_.ProductName -eq 'VMware Tools' } |
+            Select-Object -First 1
+
+        if ($entry) {
+            Write-RemovalLog "Found VMware Tools installer entry at $root (ProductCode=$($entry.PSChildName))."
+            return $entry
+        }
+    }
+
+    Write-RemovalLog 'No VMware Tools installer entry was found in either uninstall hive.'
+    return $null
+}
+
+function Stop-VMwareToolsProcesses {
+    $process_names = @(
+        'vmtoolsd',
+        'vmwaretray',
+        'vmacthlp',
+        'vmwareuser',
+        'VGAuthService'
+    )
+
+    Get-Process -Name $process_names -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Write-ServiceInventory {
+    param(
+        [array]$Services,
+        [string]$Title
+    )
+
+    Write-RemovalLog $Title
+    if (-not $Services -or $Services.Count -eq 0) {
+        Write-RemovalLog ' - none'
+        return
+    }
+
+    foreach ($service in $Services) {
+        $cim_service = Get-CimInstance -ClassName Win32_Service -Filter "Name='$($service.Name)'" -ErrorAction SilentlyContinue
+        if ($cim_service) {
+            Write-RemovalLog " - Service: $($service.Name) DisplayName=$($service.DisplayName) State=$($cim_service.State) StartMode=$($cim_service.StartMode) StartName=$($cim_service.StartName)"
+        } else {
+            Write-RemovalLog " - Service: $($service.Name) DisplayName=$($service.DisplayName) State=$($service.Status)"
         }
     }
 }
 
-function Mark-For-DeletionOnReboot($path) {
+function Mark-For-DeletionOnReboot {
+    param(
+        [string]$Path
+    )
+
     $sig = '[DllImport("kernel32.dll", SetLastError=true)] public static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);'
-    $type = Add-Type -MemberDefinition $sig -Name 'Win32MoveFileEx' -Namespace Win32Functions -PassThru
-    $type::MoveFileEx($path, $null, 4) | Out-Null
-    Write-Host "[VMWare Tools removal] Marked $path for deletion on reboot."
+    $type_name = 'Win32Functions.Win32MoveFileEx'
+    if (-not ([System.Management.Automation.PSTypeName]$type_name).Type) {
+        Add-Type -MemberDefinition $sig -Name 'Win32MoveFileEx' -Namespace Win32Functions | Out-Null
+    }
+    $type = [Win32Functions.Win32MoveFileEx]
+    $type::MoveFileEx($Path, $null, 4) | Out-Null
+    Write-RemovalLog "Marked $Path for deletion on reboot."
 }
 
-$vmware_tools_ids = Get-VMwareToolsInstallerID
+function Invoke-VMwareToolsUninstall {
+    param(
+        $InstallerEntry
+    )
 
+    if (-not $InstallerEntry) {
+        Write-RemovalLog 'No VMware Tools MSI entry found; skipping msiexec uninstall.'
+        return $false
+    }
+
+    $product_code = $InstallerEntry.PSChildName
+    if ($product_code -notmatch '^\{[0-9A-Fa-f-]+\}$') {
+        Write-RemovalLog "Found VMware Tools entry '$product_code' but it does not look like a MSI product code."
+        return $false
+    }
+
+    Write-RemovalLog "Running msiexec /x $product_code /qn /norestart."
+    $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList @('/x', $product_code, '/qn', '/norestart') -Wait -PassThru -WindowStyle Hidden
+    if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 1641 -or $process.ExitCode -eq 3010) {
+        Write-RemovalLog "msiexec completed with exit code $($process.ExitCode)."
+        return $true
+    }
+
+    Write-RemovalLog "msiexec failed with exit code $($process.ExitCode)."
+    return $false
+}
+
+$vmware_tools_entry = Get-VMwareToolsInstallerEntry
+$services = @()
 $reg_targets = @(
-    "Registry::HKEY_CLASSES_ROOT\Installer\Features\",
-    "Registry::HKEY_CLASSES_ROOT\Installer\Products\",
-    "HKLM:\SOFTWARE\Classes\Installer\Features\",
-    "HKLM:\SOFTWARE\Classes\Installer\Products\",
-    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\"
+    'Registry::HKEY_CLASSES_ROOT\Installer\Features\',
+    'Registry::HKEY_CLASSES_ROOT\Installer\Products\',
+    'HKLM:\SOFTWARE\Classes\Installer\Features\',
+    'HKLM:\SOFTWARE\Classes\Installer\Products\',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\'
 )
 
-$VMware_Tools_Directory = "C:\Program Files\VMware"
-$VMware_Common_Directory = "C:\Program Files\Common Files\VMware"
+$vmware_tools_directory = 'C:\Program Files\VMware'
+$vmware_common_directory = 'C:\Program Files\Common Files\VMware'
 
 $targets = @()
 
-if ($vmware_tools_ids) {
+if ($vmware_tools_entry) {
+    $installer_key = $vmware_tools_entry.PSChildName
     foreach ($item in $reg_targets) {
-        $targets += $item + $vmware_tools_ids.reg_id
+        $targets += $item + $installer_key
     }
-    $targets += "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{$($vmware_tools_ids.msi_id)}"
+
+    $targets += "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$installer_key"
 }
 
 if ([Environment]::OSVersion.Version.Major -lt 10) {
-    $targets += "HKCR:\CLSID\{D86ADE52-C4D9-4B98-AA0D-9B0C7F1EBBC8}"
-    $targets += "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{9709436B-5A41-4946-8BE7-2AA433CAF108}"
-    $targets += "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{FE2F6A2C-196E-4210-9C04-2B1BC21F07EF}"
+    $targets += 'HKCR:\CLSID\{D86ADE52-C4D9-4B98-AA0D-9B0C7F1EBBC8}'
+    $targets += 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{9709436B-5A41-4946-8BE7-2AA433CAF108}'
+    $targets += 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{FE2F6A2C-196E-4210-9C04-2B1BC21F07EF}'
 }
 
-if (Test-Path "HKLM:\SOFTWARE\VMware, Inc.") {
-    $targets += "HKLM:\SOFTWARE\VMware, Inc."
+if (Test-Path 'HKLM:\SOFTWARE\VMware, Inc.') {
+    $targets += 'HKLM:\SOFTWARE\VMware, Inc.'
 }
-if (Test-Path $VMware_Tools_Directory) {
-    $targets += $VMware_Tools_Directory
+if (Test-Path $vmware_tools_directory) {
+    $targets += $vmware_tools_directory
 }
-if (Test-Path $VMware_Common_Directory) {
-    $targets += $VMware_Common_Directory
+if (Test-Path $vmware_common_directory) {
+    $targets += $vmware_common_directory
 }
 
-$services = @()
-$vmware_services = Get-Service -DisplayName "VMware*" -ErrorAction SilentlyContinue
+$vmware_services = @(Get-Service -Name 'VMware*' -ErrorAction SilentlyContinue)
+if (-not $vmware_services) {
+    $vmware_services = @(Get-Service -DisplayName 'VMware*' -ErrorAction SilentlyContinue)
+}
 if ($vmware_services) { $services += $vmware_services }
-$gisvc = Get-Service -DisplayName "GISvc" -ErrorAction SilentlyContinue
-if ($gisvc) { $services += $gisvc }
-Write-Host "[VMWare Tools removal] Attempting to remove VMware Tools..."
-if (!$targets -and !$services) {
-    Write-Host "[VMWare Tools removal] Nothing to do!"
-} else {
-    Write-Host "[VMWare Tools removal] The following registry keys, filesystem folders, and services will be deleted:"
-    $targets | ForEach-Object { Write-Host " - $_" }
-    $services | ForEach-Object { Write-Host " - Service: $($_.Name)" }
 
-    if ($services.Count -gt 0) {
-        try {
-            $services | Stop-Service -Confirm:$false -ErrorAction SilentlyContinue
-            Write-Host "[VMWare Tools removal] Services stopped."
-        } catch {
-            Write-Host "[VMWare Tools removal] Warning: Failed to stop services: $_"
-        }
-
-        if (Get-Command Remove-Service -ErrorAction SilentlyContinue) {
-            $services | Remove-Service -Confirm:$false -ErrorAction SilentlyContinue
-            Write-Host "[VMWare Tools removal] Services removed using Remove-Service."
-        } else {
-            foreach ($s in $services) {
-                sc.exe DELETE $($s.Name) | Out-Null
-                Write-Host "[VMWare Tools removal] Service $($s.Name) deleted with sc.exe."
-            }
-        }
-    }
-
-    foreach ($item in $targets) {
-        if (Test-Path $item) {
-            try {
-                Remove-Item -Path $item -Recurse -Force -ErrorAction Stop
-                Write-Host "[VMWare Tools removal] Deleted: $item"
-            } catch {
-                Write-Host "[VMWare Tools removal] Could not delete $item — marking for deletion on reboot."
-                if (Test-Path $item -PathType Leaf) {
-                    Mark-For-DeletionOnReboot $item
-                }
-            }
-        }
-    }
-
-    Write-Host "[VMWare Tools removal] Done. Reboot to complete removal."
+$gisvc = @(Get-Service -Name 'GISvc' -ErrorAction SilentlyContinue)
+if (-not $gisvc) {
+    $gisvc = @(Get-Service -DisplayName 'GISvc' -ErrorAction SilentlyContinue)
 }
+if ($gisvc) { $services += $gisvc }
+
+$vgauthsvc = @(Get-Service -Name 'VGAuthService' -ErrorAction SilentlyContinue)
+if ($vgauthsvc) { $services += $vgauthsvc }
+
+Write-RemovalLog "Detected $($services.Count) service(s) matching VMware/GISvc/VGAuthService filters."
+Write-ServiceInventory -Services $services -Title 'Service inventory before uninstall:'
+
+Write-RemovalLog 'Attempting to remove VMware Tools...'
+if (-not $vmware_tools_entry -and -not $targets -and -not $services) {
+    Write-RemovalLog 'Nothing to do!'
+    exit 0
+}
+
+Write-RemovalLog 'The following registry keys, filesystem folders, and services will be deleted:'
+$targets | ForEach-Object { Write-RemovalLog " - $_" }
+$services | ForEach-Object { Write-RemovalLog " - Service: $($_.Name)" }
+
+Stop-VMwareToolsProcesses
+Write-RemovalLog 'Stopped VMware Tools-related processes if any were running.'
+Write-ServiceInventory -Services $services -Title 'Service inventory after process stop:'
+
+if ($services.Count -gt 0) {
+    try {
+        $services | Stop-Service -Confirm:$false -ErrorAction SilentlyContinue
+        Write-RemovalLog 'Services stopped.'
+    } catch {
+        Write-RemovalLog "Warning: failed to stop services: $_"
+    }
+
+    if (Get-Command Remove-Service -ErrorAction SilentlyContinue) {
+        $services | Remove-Service -Confirm:$false -ErrorAction SilentlyContinue
+        Write-RemovalLog 'Services removed using Remove-Service.'
+    } else {
+        foreach ($service in $services) {
+            sc.exe DELETE $service.Name | Out-Null
+            Write-RemovalLog "Service $($service.Name) deleted with sc.exe."
+        }
+    }
+} else {
+    Write-RemovalLog 'No VMware-related services were detected for removal.'
+}
+
+Invoke-VMwareToolsUninstall $vmware_tools_entry | Out-Null
+Write-RemovalLog 'Uninstall step finished.'
+
+foreach ($item in $targets) {
+    if (Test-Path $item) {
+        try {
+            Remove-Item -Path $item -Recurse -Force -ErrorAction Stop
+            Write-RemovalLog "Deleted: $item"
+        } catch {
+            Write-RemovalLog "Could not delete $item; marking for deletion on reboot."
+            if (Test-Path $item -PathType Leaf) {
+                Mark-For-DeletionOnReboot $item
+            }
+        }
+    }
+}
+
+Write-RemovalLog "Removal sweep completed. Remaining registry/file targets may be deleted on reboot if any were marked for deletion."
+Write-RemovalLog 'Done. Reboot to complete removal.'

--- a/tests/remove_vmtools_test.rb
+++ b/tests/remove_vmtools_test.rb
@@ -1,0 +1,38 @@
+# Unit tests for the VMware Tools removal flow
+# Run with: ruby tests/remove_vmtools_test.rb
+
+require 'minitest/autorun'
+
+class RemoveVmtoolsTest < Minitest::Test
+    def test_windows_removal_uses_explicit_powershell_command
+        source = File.read(File.expand_path('../oneswap_helper.rb', __dir__))
+
+        assert_includes source, 'def remove_vmtools_command(disk, osinfo, script_path)'
+        assert_includes source, '--copy-in'
+    end
+
+    def test_offline_service_disable_uses_virt_win_reg
+        source = File.read(File.expand_path('../oneswap_helper.rb', __dir__))
+
+        assert_includes source, 'def disable_vmtools_services_offline(disk)'
+        assert_includes source, 'virt-win-reg --merge'
+        assert_includes source, 'VMTOOLS_SERVICES_TO_DISABLE'
+        assert_includes source, 'VMTOOLS_CONTROL_SETS'
+        assert_includes source, 'VMTools'
+        assert_includes source, 'VGAuthService'
+        assert_includes source, 'ControlSet001'
+        assert_includes source, 'ControlSet002'
+        assert_includes source, 'dword:00000004'
+        assert_includes source, 'disable_vmtools_services_offline(disk) if osinfo'
+    end
+
+    def test_windows_script_tries_msi_uninstall_and_logs
+        source = File.read(File.expand_path('../scripts/vmware_tools_removal.ps1', __dir__))
+
+        assert_includes source, 'vmware_tools_removal.log'
+        assert_includes source, 'Get-VMwareToolsInstallerEntry'
+        assert_includes source, 'msiexec.exe'
+        assert_includes source, 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'
+        assert_includes source, 'Stop-VMwareToolsProcesses'
+    end
+end


### PR DESCRIPTION
### Description

Changes:
- switched Windows firstboot execution to explicit PowerShell invocation
- added offline disable for VMTools and VGAuthService in SYSTEM control sets
- resolved active control sets from HKLM\SYSTEM\Select and applied updates per control set
- added guestfish fallback and improved command error visibility via Open3.capture3
- resolved script source symlinks with File.realpath before virt-customize copy-in (prevents IntxLNK payload injection)

Result:
- VMware Tools cleanup runs on first boot automatically
- regression tests pass (3 runs, 34 assertions)

```
Creating Images in OpenNebula
Inspecting disk...Done (4.74s)
Injecting one-context...Running: virt-customize -q -a /var/tmp/oneswap2-w10/conversions/oneswap2-w10-sda --mkdir /Temp --copy-in /usr/share/one/context/one-context-7.0.0-0.msi:/Temp --firstboot-command 'msiexec -i c:\Temp\one-context-7.0.0-0.msi /quiet && del c:\Temp\one-context-7.0.0-0.msi'
Success (3.72s)
win_virtio_command cmd: virt-customize -a /var/tmp/oneswap2-w10/conversions/oneswap2-w10-sda --inject-virtio-win /usr/local/share/virtio-win/virtio-win.iso
Injecting VirtIO to Windows...Running: virt-customize -a /var/tmp/oneswap2-w10/conversions/oneswap2-w10-sda --inject-virtio-win /usr/local/share/virtio-win/virtio-win.iso
Success (10.63s)
Starting VMWare Tools Removal script injection...
Running: virt-customize -q -a /var/tmp/oneswap2-w10/conversions/oneswap2-w10-sda --mkdir /Temp --copy-in /opt/one-swap/scripts/vmware_tools_removal.ps1:/Temp --firstboot-command 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "sc config VMTools start=disabled; sc config VGAuthService start=disabled; sc stop VMTools; sc stop VGAuthService" 2>$null' --firstboot-command 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\Temp\vmware_tools_removal.ps1'
Success (4.02s)
Disabling VMware Tools services in offline registry...
VMware Tools services disabled (virt-win-reg)
VMware Tools removal script staged for first boot. Check the guest log if removal fails.
```

Tests:
```
root@ubuntu2404-255:/opt/one-swap# ruby tests/remove_vmtools_test.rb
Run options: --seed 6024

# Running:

...

Finished in 0.008516s, 352.2673 runs/s, 3992.3624 assertions/s.

3 runs, 34 assertions, 0 failures, 0 errors, 0 skips
```

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
