### PR TITLE
F OpenNebula/one#7726: Add batch VM conversion via --vm-list

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -540,6 +540,21 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    VM_LIST = {
+        :name  => 'vm_list',
+        :large => '--vm-list /path/to/vms.txt',
+        :description => 'Path to a file containing one VM name per line for batch conversion. '\
+                        'Empty lines and lines starting with # are ignored.',
+        :format => String
+    }
+
+    VMS = {
+        :name  => 'vm_names',
+        :large => '--vms vm1,vm2,...',
+        :description => 'Comma-separated list of VM names for batch conversion.',
+        :format => String
+    }
+
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
@@ -548,7 +563,7 @@ CommandParser::CmdParser.new(ARGV) do
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
-                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, ACCEPT_CERT, ONE_USER, ONE_GROUP] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
+                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, ACCEPT_CERT, ONE_USER, ONE_GROUP, VM_LIST, VMS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
     IMPORT_OPTS = [OVA, VMDK, DATASTORE, NETWORK, SKIP_CONTEXT, REMOVE_VMTOOLS, UEFI_PATH,
                    UEFI_SEC_PATH, INJECT_DNS, ONE_USER, ONE_GROUP] + V2V_OPTS
 
@@ -616,9 +631,17 @@ CommandParser::CmdParser.new(ARGV) do
 
             oneswap convert vm-1234 $VOPTS --custom
 
+            - Convert a batch of VMs from a list file (one VM name per line, # for comments):
+
+            oneswap convert --vm-list vms.txt $VOPTS [--fallback|--custom|--hybrid]
+
+            - Convert a batch of VMs specified inline (comma-separated):
+
+            oneswap convert --vms vm-web-01,vm-db-01,vm-app-01 $VOPTS [--fallback|--custom|--hybrid]
+
     EOT
 
-    command :convert, conv_desc, :vm_name, :options => CONVERT_OPTS do
+    command :convert, conv_desc, [:vm_name, nil], :options => CONVERT_OPTS do
         begin
             if options[:config_file] && !File.exist?(options[:config_file])
                 puts "Unable to find the config file at #{options[:config_file]}"
@@ -628,8 +651,8 @@ CommandParser::CmdParser.new(ARGV) do
             options.merge!(cfg_file) if cfg_file
 
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
-            raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk]
-            if options[:hybrid] && (options[:custom] || options[:esxi_ip] || options[:vddk])
+            raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk_path]
+            if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])
                 raise 'Cannot use Hybrid option with Custom, ESXi, or VDDK options.'
             end
             if options[:virtio_path] && !File.exist?(options[:virtio_path])
@@ -676,7 +699,27 @@ CommandParser::CmdParser.new(ARGV) do
                 end
             end
 
-            helper.convert(args[0], options)
+            vm_name  = args[0]
+            vm_list  = options[:vm_list]
+            vm_names = options[:vm_names]
+
+            modes = [vm_name, vm_list, vm_names].compact
+            if modes.size > 1
+                raise 'Specify only one of: positional VM name, --vms, or --vm-list.'
+            end
+            raise 'Provide a VM name, --vms vm1,vm2,..., or --vm-list <file>.' if modes.empty?
+
+            if vm_list
+                exit helper.convert_batch(vm_list, options)
+            elsif vm_names
+                names = vm_names.split(',').map(&:strip).reject(&:empty?)
+                raise '--vms requires at least one VM name' if names.empty?
+                exit helper.convert_vm_list(names, options)
+            else
+                helper.convert(vm_name, options)
+            end
+        rescue ConversionError
+            exit 1
         rescue StandardError => e
             STDERR.puts e.message
             exit 1
@@ -713,8 +756,8 @@ CommandParser::CmdParser.new(ARGV) do
             options.merge!(cfg_file) if cfg_file
 
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
-            raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk]
-            if options[:hybrid] && (options[:custom] || options[:esxi_ip] || options[:vddk])
+            raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk_path]
+            if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])
                 raise 'Cannot use Hybrid option with Custom, ESXi, or VDDK options.'
             end
             if options[:virtio_path] && !File.exist?(options[:virtio_path])

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -128,6 +128,8 @@ end
 ##############################################################################
 # Module OneVcenterHelper
 ##############################################################################
+class ConversionError < StandardError; end
+
 class OneSwapHelper < OpenNebulaHelper::OneHelper
     include WindowsTuner
 
@@ -2324,10 +2326,88 @@ _EOF_"
             password_file.close
 
             convert_vm
+        rescue StandardError => e
+            STDERR.puts "Error: #{e.message}".red
+            @logger.error "Conversion of '#{name}' failed: #{e.message}"
+            raise ConversionError, e.message
         ensure
             password_file.close unless password_file.nil? or password_file.closed?
             cleanup_all
         end
+    end
+
+    # Read and parse a VM list file for batch conversion.
+    # Empty lines and lines starting with # are ignored.
+    #
+    # @param path [String] Path to the VM list file
+    # @return [Array<String>] VM names
+    def read_vm_list(path)
+        raise "VM list file not found: #{path}" unless File.exist?(path)
+
+        File.readlines(path, chomp: true)
+            .map(&:strip)
+            .reject {|l| l.empty? || l.start_with?('#') }
+    end
+
+    # Core sequential batch loop over an array of VM names.
+    # Called by both convert_batch (--vm-list) and directly for --vms.
+    #
+    # @param vm_names [Array<String>] VM names to convert
+    # @param options  [Hash]          CLI options shared across all VMs
+    # @return [Integer] 0 if all VMs succeeded, 1 if any failed
+    def convert_vm_list(vm_names, options)
+        total   = vm_names.size
+        success = []
+        failed  = []
+
+        puts "\nBatch conversion: #{total} VM(s) queued.\n"
+
+        vm_names.each_with_index do |name, idx|
+            puts "\n[#{idx + 1}/#{total}] Converting: #{name}".bold
+            begin
+                vm_opts = options.dup
+                vm_opts[:work_dir] = options[:work_dir].dup
+                convert(name, vm_opts)
+                success << name
+            rescue StandardError => e
+                if e.is_a?(ConversionError)
+                    STDERR.puts "  [#{idx + 1}/#{total}] FAILED #{name}".red
+                else
+                    STDERR.puts "  [#{idx + 1}/#{total}] FAILED #{name}: #{e.message}".red
+                end
+                failed << name
+            end
+        end
+
+        puts "\n#{'─' * 50}"
+        puts 'Batch conversion summary:'.bold
+        puts "  Total VMs requested:   #{total}"
+        puts "  Successful conversions: #{success.size}".green
+        if failed.empty?
+            puts '  Failed conversions:  0'.green
+        else
+            puts "  Failed conversions:  #{failed.size}".red
+            puts '  Failed VM names:'.red
+            failed.each {|n| puts "    - #{n}".red }
+        end
+        puts '─' * 50
+
+        failed.empty? ? 0 : 1
+    end
+
+    # Convert a batch of VMs listed in a file (--vm-list).
+    #
+    # @param list_file [String] Path to the VM list file
+    # @param options   [Hash]   CLI options shared across all VMs
+    # @return [Integer] 0 if all VMs succeeded, 1 if any failed
+    def convert_batch(list_file, options)
+        vm_names = read_vm_list(list_file)
+
+        if vm_names.empty?
+            raise "VM list file contains no valid entries: #{list_file}"
+        end
+
+        convert_vm_list(vm_names, options)
     end
 
     # Import a VM from file (OVA, folder with files)


### PR DESCRIPTION
### Description

Add sequential batch conversion of multiple vCenter VMs in a single invocation by supplying a plain-text file with one VM per line.

CLI (oneswap):
- --vm-list <vms_file> option added to convert command
- vm_name becomes optional when --vm-list is used
- exclusion enforced between vm name and --vm-list
- exit with code 1 if any VM in batch fails

Helper (oneswap_helper.rb):
- read_vm_list(path): parses the file, strips blanks and comments
- convert_batch(names, options): sequential loop over convert_single, isolates per-VM errors so one failure does not abort the rest, prints a structured summary (total/success/failed) at the end
- convert_single: ensure block now preserves the original exception when cleanup raises

Test:
1. One VM convert (clasic):
```
root@ubuntu2404-255:/opt/one-swap# oneswap convert "oneswap-alpine" $VOPTS --accept-cert --skip-mac --delete-after --network 0 --custom
Running OpenNebula prechecks...
Downloading disks from vCenter storage to local disk
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5120M  100 5120M    0     0  40.2M      0  0:02:07  0:02:07 --:--:-- 35.4M
Downloaded disk #0.
Converting disks locally
    (100.00/100%)
Disk 0 converted in 0.59 seconds. Deleting vmdk file
Creating Images in OpenNebula
Inspecting disk...Done (3.33s)
Alpine is not compatible with offline install, please install context manually.
Unsupported guest OS or couldn't find context file for context injection. Please install manually.
Allocating image 0 in OpenNebula
Waiting for image to be ready. Timeout: 120 seconds.
Allocated images in OpenNebula in (4.03s)
Created images: [{:id=>24, :os=>"linux"}]
Adding 1 NICs, assigning networks from 0
Skipping MAC address for NIC#0
No VCENTER_NETWORK_MATCH found for 'vms'. Using assigned network: 0
Found network 'vms' but no guest network information. Adding blank NIC.
Allocating the VM template...Success
VM Template ID: 24
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-alpine/conversions
Deleting everything in and including /var/tmp/oneswap-alpine
```

2. Batchconvert (new added):
```
root@ubuntu2404-255:/opt/one-swap# oneswap convert --vm-list vms.txt $VOPTS --accept-cert --custom --skip-mac --delete-after --network 0

[1/3] Converting VM 'oneswap-alpine'
Running OpenNebula prechecks...
Downloading disks from vCenter storage to local disk
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5120M  100 5120M    0     0  40.7M      0  0:02:05  0:02:05 --:--:-- 38.3M
Downloaded disk #0.
Converting disks locally
    (100.00/100%)
Disk 0 converted in 0.65 seconds. Deleting vmdk file
Creating Images in OpenNebula
Inspecting disk...Done (3.32s)
Alpine is not compatible with offline install, please install context manually.
Unsupported guest OS or couldn't find context file for context injection. Please install manually.
Allocating image 0 in OpenNebula
Waiting for image to be ready. Timeout: 120 seconds.
Allocated images in OpenNebula in (4.05s)
Created images: [{:id=>25, :os=>"linux"}]
Adding 1 NICs, assigning networks from 0
Skipping MAC address for NIC#0
No VCENTER_NETWORK_MATCH found for 'vms'. Using assigned network: 0
Found network 'vms' but no guest network information. Adding blank NIC.
Allocating the VM template...Success
VM Template ID: 25
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-alpine/conversions
Deleting everything in and including /var/tmp/oneswap-alpine

[2/3] Converting VM 'oneswap-u2404'
Running OpenNebula prechecks...
Downloading disks from vCenter storage to local disk
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.0G  100 15.0G    0     0  40.4M      0  0:06:20  0:06:20 --:--:-- 35.0M
Downloaded disk #0.
Converting disks locally
    (100.00/100%)
Disk 0 converted in 9.94 seconds. Deleting vmdk file
Creating Images in OpenNebula
Inspecting disk...Done (4.33s)
Injecting one-context...Running: virt-customize -q -a /var/tmp/oneswap-u2404/conversions/oneswap-u2404-disk0.qcow2 --uninstall cloud-init --copy-in /usr/share/one/context/one-context_7.0.0-0.deb:/tmp --install /tmp/one-context_7.0.0-0.deb --delete /tmp/one-context_7.0.0-0.deb --run-command 'systemctl enable network.service || exit 0'
Success (28.09s)
Allocating image 0 in OpenNebula
Waiting for image to be ready. Timeout: 120 seconds.
Allocated images in OpenNebula in (39.89s)
Created images: [{:id=>26, :os=>"linux"}]
Adding 1 NICs, assigning networks from 0
Skipping MAC address for NIC#0
No VCENTER_NETWORK_MATCH found for 'vms'. Using assigned network: 0
Found network 'vms' but no guest network information. Adding blank NIC.
Allocating the VM template...Success
VM Template ID: 26
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-u2404/conversions
Deleting everything in and including /var/tmp/oneswap-u2404

[3/3] Converting VM 'oneswap-not_exist'
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-not_exist/conversions
Deleting everything in and including /var/tmp/oneswap-not_exist
Failed converting 'oneswap-not_exist': Unable to find Virtual Machine by name 'oneswap-not_exist'

Batch conversion summary
Total VMs requested: 3
Successful conversions: 2
Failed conversions: 1
Failed VM names: oneswap-not_exist
```
<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
