### PR TITLE
F #7698: [OneSwap] fix InvalidProperty when listing cluster

### DIFF
--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2462,7 +2462,7 @@ _EOF_"
 
         list = []
         properties = [
-            'summary.usageSummary.totalVmCount',
+            'resourcePool',
             'name'
         ]
 
@@ -2478,10 +2478,19 @@ _EOF_"
             conf = c.to_hash
             v = {}
             v[:name] = conf['name'].to_s
-            v[:vm_count] = conf['summary.usageSummary.totalVmCount']
+            v[:vm_count] = resource_pool_vm_count(conf['resourcePool'])
             list << v
         end
         format_list.show(list, options)
+    end
+
+    def resource_pool_vm_count(resource_pool)
+        return 0 if resource_pool.nil?
+
+        vms = Array(resource_pool[:vm])
+        child_pools = Array(resource_pool[:resourcePool])
+
+        vms.length + child_pools.sum {|child| resource_pool_vm_count(child) }
     end
 
     # Import VM


### PR DESCRIPTION
### Description

fixes OpenNebula/one#7698

`oneswap list clusters` previously requested `summary.usageSummary.totalVmCount` to display the number of VMs in each cluster. On vCenter 8.0.3, this may fail with:

```
InvalidProperty: summary.usageSummary.totalVmCount
```
This change avoids requesting summary.usageSummary.totalVmCount. Instead, OneSwap requests the cluster root resourcePool and calculates the VM count recursively from the resource pool hierarchy.

Validated against a vCenter 8.0.3 environment:
```
oneswap list clusters $vcauth
NAME                                                                                                                                                             VMCOUNT                              
OpenNebula_Cluster                                                                                                                                               24
oneswap list vms $vcauth | grep vm | wc -l
24
```

### Branches to which this PR applies

- [ ] master
- [ ] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
