### PR TITLE
F #835: Check guest OS free disk space during context injection

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -322,6 +322,31 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    CONTEXT_MIN_FREE = {
+        :name => 'context_min_free',
+        :large => '--context-min-free MB',
+        :description => 'Minimum free space (in MB) required on the guest root filesystem before context '\
+                        'injection. If free space is below this threshold oneswap warns and skips injection '\
+                        '(or fails the disk conversion with --context-fail-on-low-space). Set to 0 to disable '\
+                        'the check. Default: 1024',
+        :format => Integer
+    }
+
+    CONTEXT_FAIL_LOW_SPACE = {
+        :name => 'context_fail_on_low_space',
+        :large => '--context-fail-on-low-space',
+        :description => 'Fail the disk conversion instead of warning and skipping when the guest root '\
+                        'filesystem free space is below --context-min-free.'
+    }
+
+    CONTEXT_TIMEOUT = {
+        :name => 'context_timeout',
+        :large => '--context-timeout SECONDS',
+        :description => 'Maximum time (in seconds) allowed for each context injection command before it is '\
+                        'aborted. Set to 0 to disable. Default: 600',
+        :format => Integer
+    }
+
     ESXI = {
         :name => 'esxi_ip',
         :large => '--esxi ip',
@@ -563,9 +588,11 @@ CommandParser::CmdParser.new(ARGV) do
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
-                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, ACCEPT_CERT, ONE_USER, ONE_GROUP, VM_LIST, VMS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
+                    SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
+                    ACCEPT_CERT, ONE_USER, ONE_GROUP, VM_LIST, VMS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
     IMPORT_OPTS = [OVA, VMDK, DATASTORE, NETWORK, SKIP_CONTEXT, REMOVE_VMTOOLS, UEFI_PATH,
-                   UEFI_SEC_PATH, INJECT_DNS, ONE_USER, ONE_GROUP] + V2V_OPTS
+                   UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
+                   ONE_USER, ONE_GROUP] + V2V_OPTS
 
     ############################################################################
     # list resources
@@ -673,16 +700,18 @@ CommandParser::CmdParser.new(ARGV) do
                 raise 'Cannot define both --fallback and --custom.'
             end
 
-            options[:work_dir]       ||= WORK_PATH
-            options[:format]         ||= 'qcow2'
-            options[:context]        ||= '/usr/share/one/context'
-            options[:esxi_user]      ||= 'root'
-            options[:datastore]      ||= 1
-            options[:virt_tools]     ||= '/usr/local/share/virt-tools'
-            options[:v2v_path]       ||= 'virt-v2v'
-            options[:remove_vmtools] ||= false
-            options[:clone]          ||= false
-            options[:skip_prechecks] ||= false
+            options[:work_dir]         ||= WORK_PATH
+            options[:format]           ||= 'qcow2'
+            options[:context]          ||= '/usr/share/one/context'
+            options[:esxi_user]        ||= 'root'
+            options[:datastore]        ||= 1
+            options[:virt_tools]       ||= '/usr/local/share/virt-tools'
+            options[:v2v_path]         ||= 'virt-v2v'
+            options[:remove_vmtools]   ||= false
+            options[:clone]            ||= false
+            options[:skip_prechecks]   ||= false
+            options[:context_min_free] ||= 1024
+            options[:context_timeout]  ||= 600
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|
@@ -775,14 +804,16 @@ CommandParser::CmdParser.new(ARGV) do
                 end
             end
 
-            options[:work_dir]      ||= WORK_PATH
-            options[:format]        ||= 'qcow2'
-            options[:context]       ||= '/usr/share/one/context/'
-            options[:datastore]     ||= 1
-            options[:virt_tools]    ||= '/usr/local/share/virt-tools'
-            options[:v2v_path]      ||= 'virt-v2v'
-            options[:root]          ||= 'first'
-            options[:remove_vmtools] ||= false
+            options[:work_dir]         ||= WORK_PATH
+            options[:format]           ||= 'qcow2'
+            options[:context]          ||= '/usr/share/one/context/'
+            options[:datastore]        ||= 1
+            options[:virt_tools]       ||= '/usr/local/share/virt-tools'
+            options[:v2v_path]         ||= 'virt-v2v'
+            options[:root]             ||= 'first'
+            options[:remove_vmtools]   ||= false
+            options[:context_min_free] ||= 1024
+            options[:context_timeout]  ||= 600
 
             helper.import(options)
         rescue StandardError => e

--- a/oneswap.1
+++ b/oneswap.1
@@ -178,7 +178,7 @@ Examples:
     You can also define \-\-fallback instead of \-\-custom, which will first attempt virt\-v2v style, then fallback to custom\.
 
     oneswap convert vm\-1234 $VOPTS \-\-custom
-valid options: accept_cert, clone, config_file, context, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
+valid options: accept_cert, clone, config_file, context, context_fail_on_low_space, context_min_free, context_timeout, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, inject_dns, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
 .
 .fi
 .
@@ -204,7 +204,7 @@ Examples:
    \- import Image from an VMDK file:
 
      oneswap import \-\-vmdk disk\.vmdk
-valid options: datastore, delete, format, network, ova, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_context, uefi_path, uefi_sec_path, v2v_path, vddk_path, virt_tools, virtio_path, vmdk, work_dir
+valid options: context_fail_on_low_space, context_min_free, context_timeout, datastore, delete, format, inject_dns, network, ova, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_context, uefi_path, uefi_sec_path, v2v_path, vddk_path, virt_tools, virtio_path, vmdk, work_dir
 .
 .fi
 .

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -49,6 +49,9 @@
 # Extra Options
 #:delete: false                           # Delete the VM Disks after transfer
 #:context: '/var/lib/one/context/'        # Path to OpenNebula context packages
+#:context_min_free: 1024                  # Minimum free MB on the guest root filesystem before context injection (0 to disable)
+#:context_fail_on_low_space: false        # Fail the disk conversion (instead of warning and skipping) when free space is below the threshold
+#:context_timeout: 600                    # Max seconds for each context injection command before it is aborted (0 to disable)
 #:remove-vmtools: false                   # Add context script to force remove of VMWare Tools
 #:uefi_path: '/usr/share/OVMF/OVMF_CODE.fd'                 # Path to the UEFI file to be configured in the VM template.
 #:uefi_sec_path: '/usr/share/OVMF/OVMF_CODE.secboot.fd'     # Path to the UEFI Secure file to be configured in the VM template.

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -928,20 +928,64 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
     #
     # @param cmd [String] The command to be executed.
     # @param out [Boolean] (optional) Whether to return the output or not.
+    # @param timeout [Integer, nil] (optional) Abort the command if it runs longer than this specified number of seconds, 0 disables timeout.
     # @return [Array] Returns an array containing the stdout and status if out is true.
-    def run_cmd_report(cmd, out = false)
+    def run_cmd_report(cmd, out = false, timeout: nil)
         t0 = Time.now
         stdout, stderr, status = nil
+        timed_out = false
         puts "Running: #{cmd}"
         show_wait_spinner do
-            stdout, stderr, status = Open3.capture3(cmd)
+            if timeout && timeout.to_i > 0
+                stdout, stderr, status, timed_out = run_cmd_with_timeout(cmd, timeout.to_i)
+            else
+                stdout, stderr, status = Open3.capture3(cmd)
+            end
         end
         t1 = (Time.now - t0).round(2)
-        puts !status.success? ? "Failed (#{t1}s)".red : "Success (#{t1}s)".green
+        if timed_out
+            puts "Timed out after #{t1}s".red
+        else
+            puts !status.success? ? "Failed (#{t1}s)".red : "Success (#{t1}s)".green
+        end
 
-        @logger.debug(stderr) unless status.success?
+        @logger.debug(stderr) unless status&.success?
 
         return stdout, status if out
+    end
+
+    # Runs a command, terminating it if exceeds the given amount of seconds
+    #
+    # @return [Array] [stdout, stderr, status, timed_out]
+    def run_cmd_with_timeout(cmd, timeout)
+        timed_out = false
+        stdout = stderr = ''
+        status = nil
+
+        Open3.popen3(cmd, :pgroup => true) do |stdin, out_io, err_io, wait_thr|
+            stdin.close
+            out_reader = Thread.new { out_io.read }
+            err_reader = Thread.new { err_io.read }
+
+            unless wait_thr.join(timeout)
+                timed_out = true
+                kill_process_group(wait_thr.pid)
+            end
+
+            status = wait_thr.value
+            stdout = out_reader.value.to_s
+            stderr = err_reader.value.to_s
+        end
+
+        [stdout, stderr, status, timed_out]
+    end
+
+    # Sends TERM then KILL to the process group led by pid
+    def kill_process_group(pid)
+        Process.kill('TERM', -pid)
+        sleep 5
+        Process.kill('KILL', -pid)
+    rescue Errno::ESRCH, Errno::EPERM
     end
 
     def detect_distro(disk)
@@ -1298,9 +1342,65 @@ _EOF_"
               " --install #{pkg}"
     end
 
-    def install_pkg(disk, pkg)
+    def install_pkg(disk, pkg, timeout: nil)
         print "Installing #{pkg}..."
-        run_cmd_report(pkg_install_command(disk, pkg))
+        run_cmd_report(pkg_install_command(disk, pkg), false, timeout: timeout)
+    end
+
+    # Returns the free space (in MB) on the guest root filesystem, or nil if it cannot be determined
+    def guest_root_free_mb(disk, osinfo)
+        root_dev = osinfo['mounts'] && osinfo['mounts']['/']
+        return nil unless root_dev
+
+        cmd = 'guestfish --ro'\
+              " -a #{disk}"\
+              " run : mount-ro #{root_dev} / : statvfs /"
+        stdout, stderr, status = Open3.capture3(cmd)
+        unless status.success?
+            @logger.debug("Could not stat guest root filesystem: #{stderr}")
+            return nil
+        end
+
+        # guestfish prints the statvfs struct as "key: value" lines
+        stats = {}
+        stdout.each_line do |line|
+            key, val = line.split(':', 2).map {|s| s.to_s.strip }
+            stats[key] = val.to_i if !key.to_s.empty? && val.to_s =~ /\A\d+\z/
+        end
+
+        block_size = stats['frsize'].to_i > 0 ? stats['frsize'].to_i : stats['bsize'].to_i
+        avail = stats['bavail']
+        return nil unless block_size > 0 && avail
+
+        (avail * block_size) / (1024 * 1024)
+    rescue StandardError => e
+        @logger.debug("Error checking guest free space: #{e.message}")
+        nil
+    end
+
+    # Verifies the guest root filesystem has enough free space for context
+    # injection. Returns true if injection should proceed, false if it should be
+    # skipped (warn mode). Raises ConversionError when --context-fail-on-low-space
+    # is set and free space is insufficient.
+    def ensure_guest_free_space(disk, osinfo)
+        min_free = @options[:context_min_free].to_i
+        return true if min_free <= 0
+
+        free_mb = guest_root_free_mb(disk, osinfo)
+        if free_mb.nil?
+            puts 'Warning: could not determine guest root filesystem free space, proceeding with context injection.'.brown
+            return true
+        end
+
+        return true if free_mb >= min_free
+
+        msg = "Guest root filesystem has only #{free_mb} MB free, below the #{min_free} MB " \
+              'required for context injection.'
+        raise ConversionError, msg if @options[:context_fail_on_low_space]
+
+        puts msg.red
+        puts 'Skipping context injection to avoid hanging; install one-context manually after boot.'.brown
+        false
     end
 
     def guest_run_cmd(disk, cmd)
@@ -1314,24 +1414,26 @@ _EOF_"
 
     def package_injection(disk, osinfo)
         injector_cmd, fallback_cmd = context_command(disk, osinfo)
+        ctx_timeout = @options[:context_timeout]
         if !injector_cmd
             if osinfo['name'] == 'windows'
-                win_context_inject(disk, osinfo)
+                win_context_inject(disk, osinfo) if ensure_guest_free_space(disk, osinfo)
             else
                 puts 'Unsupported guest OS or couldn\'t find context file for context injection. Please install manually.'.brown
             end
         elsif @options[:skip_context]
             print 'Skipping context injection...'
             return
-        else
-            # Perhaps have a separet function that does a bit more....stuff...
+        elsif ensure_guest_free_space(disk, osinfo)
             print 'Injecting one-context...'
-            _stdout, status = run_cmd_report(injector_cmd, true)
+            _stdout, status = run_cmd_report(injector_cmd, true, timeout: ctx_timeout)
             if !status.success?
-                print 'Context injection command appears to have failed. Attempting fallback'.brown
-                _stdout, status = run_cmd_report(fallback_cmd, true)
+                if fallback_cmd
+                    print 'Context injection command appears to have failed. Attempting fallback'.brown
+                    _stdout, status = run_cmd_report(fallback_cmd, true, timeout: ctx_timeout)
+                end
                 if !status.success?
-                    puts 'Context injection fallback command failed somehow, please install context manually.'.red
+                    puts 'Context injection failed, please install context manually.'.red
                     return
                 end
                 print 'Context will install on first boot, you may need to boot it twice.'.brown
@@ -1341,18 +1443,18 @@ _EOF_"
         if osinfo['name'] == 'windows' && @options[:virtio_path]
             injector_cmd = win_virtio_command(disk)
             print 'Injecting VirtIO to Windows...'
-            run_cmd_report(injector_cmd)
+            run_cmd_report(injector_cmd, false, timeout: ctx_timeout)
         end
 
         if @options[:qemu_ga_win] && osinfo['name'] == 'windows'
             injector_cmd = qemu_ga_command(disk)
             print 'Injecting QEMU Guest Agent...'
-            run_cmd_report(injector_cmd)
+            run_cmd_report(injector_cmd, false, timeout: ctx_timeout)
         end
 
         return unless @options[:qemu_ga_linux] && osinfo['name'] != 'windows'
 
-        install_pkg(disk, 'qemu-guest-agent')
+        install_pkg(disk, 'qemu-guest-agent', timeout: ctx_timeout)
     end
 
     def get_objects(vim, type, properties, folder = nil)

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1762,6 +1762,8 @@ _EOF_"
             end
 
             create_one_images(disks_on_file)
+        rescue ConversionError
+            raise
         rescue StandardError => e
             # puts "Error raised: #{e.message}"
             if @props['config'][:guestFullName].include?('Windows')
@@ -1978,6 +1980,8 @@ _EOF_"
                     remove_vmtools_injection(d, guest_info)
                     os_name = guest_info['name']
                 end
+            rescue ConversionError
+                raise
             rescue Exception => e
                 if guest_info['name'] == 'windows'
                     puts 'Error with package injection. Conversion failed. Check that you have virtio and context packages in place.'.red


### PR DESCRIPTION
### Description

Changes

- **Pre-flight free-space check**  before running virt-customize it inspect guest root filesystem and compare free space against threshold
- **Timeout around injection** context-injection commands run under a configurable timeout. Once expired process group is terminated
- **Configurable low-space behaviour** default it warn and skip injection (migration continues and guest can install context manually). With param --context-fail-on-low-space it abort the disk conversion
- The low space failure propagates and is not retried via --fallback or --hybrid conversions. In batch mode (--vm-list or --vms) it marks that VM as failed and continue.

All conversion modes (default virt-v2v, vddk, esxi, ova, hybrid, custom and delta) go through create_one_images -> package_injection and behaviour is uniform.

New options (available on convert and import as well):

| Option | Default | Description |
|--------|---------|-------------|
| `--context-min-free MB` | `1024` | Minimum free space (MB) required on the guest root FS before injection. 0 disable check. |
| `--context-fail-on-low-space` | `off` | Fail disk conversion instead of warning + skip when below the threshold. |
| `--context-timeout SECONDS` | `600` | Max seconds per injection command before being aborted. 0 disable timeout. |

Same keys can be set in oneswap.yaml (context_min_free, context_fail_on_low_space, context_timeout).

Behaviour:

| Condition | Default (warn) | `--context-fail-on-low-space` |
|-----------|----------------|-------------------------------|
| Free space below threshold | Warn  + skip injection, migration continues | Abort disk conversion, no image/template created |
| Free space could not be determined | Warn + proceed | Warn + proceed |
| Injection param exceed --context-timeout | Try fallback, on second timeout warn + continue | Same (timeout is not affected by the fail flag) |

Tests:

<details>
<summary>1. Base -> normal injection</summary>

`oneswap convert oneswap-u2404 $VOPTS --delete-after`
```
Creating Images in OpenNebula
Inspecting disk...Done (4.11s)
Injecting one-context...Running: virt-customize -q -a .../oneswap-u2404-sda --uninstall cloud-init --copy-in .../one-context_7.2.1-0.deb:/tmp --install ... --delete ... --run-command 'systemctl enable network.service || exit 0'
Success (34.03s)
Allocating image 0 in OpenNebula
Created images: [{:id=>2, :os=>"linux"}]
VM Template ID: 2
```
</details>

<details>
<summary>2. <code>--context-min-free 9999999</code> -> low space(warn + skip)</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (4.32s)
Guest root filesystem has only 7568 MB free, below the 9999999 MB required for context injection.
Skipping context injection to avoid hanging; install one-context manually after boot.
Allocating image 0 in OpenNebula
Created images: [{:id=>3, :os=>"linux"}]
VM Template ID: 3
```
</details>

<details>
<summary>3. <code>--context-min-free 9999999 --context-fail-on-low-space</code> -> hard abort (exit 1)</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (4.62s)
Error: Guest root filesystem has only 7568 MB free, below the 9999999 MB required for context injection.
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-u2404/conversions
Deleting everything in and including /var/tmp/oneswap-u2404
```
No image/template created.
</details>

<details>
<summary>4. <code>--context-min-free 0</code> -> check disabled, injection proceed</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (4.01s)
Injecting one-context...Running: virt-customize -q -a .../oneswap-u2404-sda --uninstall cloud-init --copy-in ... --install ... --delete ...
Success (33.3s)
Allocating image 0 in OpenNebula
Created images: [{:id=>5, :os=>"linux"}]
VM Template ID: 5
```
</details>

<details>
<summary>5. <code>--context-min-free 0 --context-timeout 1</code> -> injection time out</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (3.91s)
Injecting one-context...Running: virt-customize -q -a .../oneswap-u2404-sda --uninstall cloud-init --copy-in ... --install ...
Timed out after 6.02s
Context injection command appears to have failed. Attempting fallbackRunning: virt-customize ... --firstboot-install ...
Timed out after 6.01s
Context injection failed, please install context manually.
Allocating image 0 in OpenNebula
Created images: [{:id=>6, :os=>"linux"}]
VM Template ID: 6
```
</details>

<details>
<summary>6. <code>--context-min-free 9999999 --context-timeout 1</code> -> space check run first, timeout never reached</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (4.22s)
Guest root filesystem has only 7568 MB free, below the 9999999 MB required for context injection.
Skipping context injection to avoid hanging; install one-context manually after boot.
Allocating image 0 in OpenNebula
Created images: [{:id=>1, :os=>"linux"}]
VM Template ID: 1
```
</details>

<details>
<summary>7. <code>--context-min-free 0 --context-fail-on-low-space --context-timeout 1</code> -> fail flag does not apply to timeouts</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (4.12s)
Injecting one-context...Running: virt-customize -q -a .../oneswap-u2404-sda --uninstall cloud-init --copy-in ... --install ...
Timed out after 6.01s
Context injection command appears to have failed. Attempting fallbackRunning: virt-customize ... --firstboot-install ...
Timed out after 6.02s
Context injection failed, please install context manually.
Allocating image 0 in OpenNebula
Created images: [{:id=>7, :os=>"linux"}]
VM Template ID: 7
```
Space is fine, injection run and times out (warn + continue)
</details>

<details>
<summary>8. <code>--context-timeout 1800</code> -> huge timeout, normal injection</summary>

```
Creating Images in OpenNebula
Inspecting disk...Done (3.92s)
Injecting one-context...Running: virt-customize -q -a .../oneswap-u2404-sda --uninstall cloud-init --copy-in ... --install ...
Success (31.7s)
Allocating image 0 in OpenNebula
Created images: [{:id=>8, :os=>"linux"}]
VM Template ID: 8
```
</details>

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
