### PR TITLE
F #7747: [OneSwap] Windows VM migration when CompactOS is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,49 @@ The following packages must be installed on the conversion host:
 | `qemu-img` | All conversion modes |
 | `ovmf` | Migrating UEFI guests (provides OVMF firmware for x86-64); without it `virt-v2v` will fail with *"cannot find firmware for UEFI guests"* |
 | `guestfish` / `virt-inspector` | Windows context injection and disk inspection |
+| `nbdkit` (with VDDK plugin) | `--vddk` transfers; Debian/Ubuntu packages do not ship the VDDK plugin — see [VDDK Transfer Support](#vddk-transfer-support) |
 
 When installing OneSwap via the provided packages all dependencies are installed automatically. If deploying from source, the dependencies listed in the table above must be installed manually using the system package manager.
+
+## Windows CompactOS Support
+
+Windows guests that use NTFS system compression (CompactOS / WOF) fail
+conversion with `inspection could not detect the source guest` /
+`No root device found`, because the ntfs-3g inside the libguestfs appliance
+cannot read WOF-compressed system files. You can check a guest from an
+elevated prompt with:
+
+```
+compact /compactos:query
+```
+
+To enable CompactOS support, run once on each migration host (as root):
+
+```
+/usr/lib/one/oneswap/scripts/setup_ntfs_wof.sh
+```
+
+The script builds the
+[ntfs-3g-system-compression](https://github.com/ebiggers/ntfs-3g-system-compression)
+plugin, installs it, and packs it as a supermin.d overlay so every libguestfs
+appliance rebuild includes it automatically (no fixed appliance or
+`LIBGUESTFS_PATH` needed). It requires internet access, or an internal mirror
+via the `NTFS_WOF_REPO_URL` environment variable.
+
+## VDDK Transfer Support
+
+`--vddk` transfers require the nbdkit VDDK plugin, which Debian/Ubuntu
+packages do not ship (on RHEL install the `nbdkit-vddk-plugin` package). To
+build and install it, run once on each migration host (as root):
+
+```
+/usr/lib/one/oneswap/scripts/setup_nbdkit_vddk.sh
+```
+
+The script builds the nbdkit version matching the installed distro package
+and copies only the VDDK plugin into nbdkit's plugin directory. It requires
+internet access, or an internal mirror via the `NBDKIT_REPO_URL` environment
+variable.
 
 ## vCenter Permissions Requirements
 

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1747,7 +1747,7 @@ _EOF_"
             print "\n"
             # puts "Process exited with status: #{exit_status}"
             if error_check
-                raise "Error: #{error_check.message}"
+                raise error_check
             end
             if exit_status != 0
                 raise "virt-v2v exited in error code #{exit_status} but did not provide an error"
@@ -1849,7 +1849,21 @@ _EOF_"
         error_list = [
             {
                 :text  => 'inspection could not detect the source guest',
-                :error => 'Could not find the guest OS inside the target machine.'
+                :error => 'Could not find the guest OS inside the target machine.',
+                :windows_hint => "For Windows guests this failure is usually caused by:\n" \
+                    "  - NTFS system compression (CompactOS). Check inside the guest with\n" \
+                    "    'compact /compactos:query'. Fix it with 'compact /compactos:never' and\n" \
+                    "    a clean shutdown, or run\n" \
+                    "    /usr/lib/one/oneswap/scripts/setup_ntfs_wof.sh\n" \
+                    "    once on this conversion host.\n" \
+                    "  - BitLocker encryption on the system volume.\n" \
+                    '  - Hibernation / Fast Startup leaving the NTFS volume dirty.'
+            },
+            {
+                :text  => 'nbdkit-vddk-plugin is not installed',
+                :error => "nbdkit on this conversion host is missing the VDDK plugin\n" \
+                          "(Debian/Ubuntu packages do not ship it). Run once on this host:\n" \
+                          '  /usr/lib/one/oneswap/scripts/setup_nbdkit_vddk.sh'
             },
             {
                 :text  => 'virt-v2v is unable to convert this guest type',
@@ -1857,15 +1871,11 @@ _EOF_"
             },
             {
                 :text  => 'unable to mount the disk image for writing',
-                :error => 'Disk did not mount properly, try disabling Windows Hiberanation or Fast Restart in this guest.'
+                :error => 'Disk did not mount properly, try disabling Windows Hibernation or Fast Restart in this guest.'
             },
             {
                 :text  => 'filesystem was mounted read-only, even though',
-                :error => 'Disk mountd read-only, try disabling Windows Hiberation or Fast Restart in this guest and cleanly shut it down.'
-            },
-            {
-                :text  => 'inspection could not detect the source guest',
-                :error => 'Unable to find, or inspect, the OS disk'
+                :error => 'Disk mounted read-only, try disabling Windows Hibernation or Fast Restart in this guest and cleanly shut it down.'
             },
             {
                 :text  => 'multi-boot operating systems are not supported',
@@ -1890,7 +1900,16 @@ _EOF_"
 
         err = error_list.detect {|e| line['message'].start_with?(e[:text]) }
         puts "DEBUG INFO: #{line['message']}".red
-        err ? raise(err[:error].red) : raise("Unknown error occurred: #{line['message']}".bg_red)
+        raise("Unknown error occurred: #{line['message']}".bg_red) unless err
+
+        msg = err[:error]
+        # 'config' is a RbVmomi object on the vCenter path and a Hash on the
+        # OVA path; both support [], neither is guaranteed to have #dig.
+        config = @props.to_h['config']
+        if err[:windows_hint] && config && config[:guestFullName].to_s.include?('Windows')
+            msg = "#{msg}\n#{err[:windows_hint]}"
+        end
+        raise(msg.red)
     end
 
     def handle_stdout(line)
@@ -2486,6 +2505,47 @@ GUESTFISH
         puts 'VMware Tools removal script staged for first boot. Check the guest log if removal fails.'.green
     end
 
+    # Warn when the conversion host cannot read CompactOS/WOF-compressed NTFS
+    #
+    # @param plugin_globs  [Array<String>] globs for the ntfs-3g plugin .so
+    # @param overlay_globs [Array<String>] globs for the supermin.d overlay
+    # @param env           [Hash] environment (injectable for tests)
+    # @return [Boolean] true when a warning was printed
+    def warn_if_wof_support_missing(
+        plugin_globs: ['/usr/lib/*/ntfs-3g/ntfs-plugin-80000017.so',
+                       '/usr/lib64/ntfs-3g/ntfs-plugin-80000017.so'],
+        overlay_globs: ['/usr/lib/*/guestfs/supermin.d/zz-ntfs-wof.tar.gz'],
+        env: ENV
+    )
+        return false unless env['LIBGUESTFS_PATH'].to_s.empty?
+        return false if plugin_globs.any? {|g| !Dir.glob(g).empty? }
+        return false if overlay_globs.any? {|g| !Dir.glob(g).empty? }
+
+        puts 'Warning: this host cannot read CompactOS-compressed NTFS. Windows'.brown
+        puts 'guests using CompactOS will fail inspection. Run once on this host:'.brown
+        puts '  /usr/lib/one/oneswap/scripts/setup_ntfs_wof.sh'.brown
+        true
+    end
+
+    # Fail fast when --vddk is requested but nbdkit lacks the VDDK plugin.
+    #
+    # @param plugin_globs [Array<String>] globs for nbdkit-vddk-plugin.so
+    # @return [void]
+    def check_nbdkit_vddk_plugin!(
+        plugin_globs: ['/usr/lib/*/nbdkit/plugins/nbdkit-vddk-plugin.so',
+                       '/usr/lib64/nbdkit/plugins/nbdkit-vddk-plugin.so',
+                       '/usr/local/lib/nbdkit/plugins/nbdkit-vddk-plugin.so']
+    )
+        return if plugin_globs.any? {|g| !Dir.glob(g).empty? }
+
+        msg = "nbdkit on this conversion host is missing the VDDK plugin, which is\n" \
+              "required for --vddk transfers (Debian/Ubuntu packages do not ship it).\n" \
+              "Run once on this host:\n" \
+              "  /usr/lib/one/oneswap/scripts/setup_nbdkit_vddk.sh\n" \
+              'or pass --skip-prechecks to bypass this check.'
+        raise(msg.red)
+    end
+
     # Run a OpenNebula system prechecks:
     #
     # - Check if there is enough space in the datastore
@@ -2495,6 +2555,11 @@ GUESTFISH
     #
     def one_prechecks(vm)
         puts 'Running OpenNebula prechecks...'
+        config = @props.to_h['config']
+        if config && config[:guestFullName].to_s.include?('Windows')
+            warn_if_wof_support_missing
+        end
+        check_nbdkit_vddk_plugin! if @options[:vddk_path]
         ## Precheck datastore space (check if it will be enough space for the image)
         vm_obj = vm.obj
         vm_size_kb = 0

--- a/scripts/setup_nbdkit_vddk.sh
+++ b/scripts/setup_nbdkit_vddk.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2026, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# setup_nbdkit_vddk.sh
+#
+# One-time, idempotent setup that gives nbdkit the VDDK plugin required by
+# virt-v2v's '-it vddk' mode (oneswap --vddk). Debian/Ubuntu do not package
+# the plugin, so it is built from the nbdkit sources matching the installed
+# distro package, and only the plugin .so is copied into nbdkit's plugindir
+# (no 'make install', which would install a parallel nbdkit in /usr/local).
+
+set -euo pipefail
+
+REPO_URL="${NBDKIT_REPO_URL:-https://gitlab.com/nbdkit/nbdkit.git}"
+PLUGIN_NAME="nbdkit-vddk-plugin.so"
+FORCE="no"
+VERIFY="yes"
+
+usage() {
+    cat <<'EOF'
+Usage: setup_nbdkit_vddk.sh [--force] [--no-verify] [-h|--help]
+
+Builds and installs the nbdkit VDDK plugin required for oneswap --vddk
+transfers. Run once, as root, on the migration host.
+
+Options:
+  --force      redo the setup even if the plugin is already installed
+  --no-verify  skip the 'nbdkit vddk --dump-plugin' verification step
+  -h, --help   show this help
+
+Environment overrides:
+  NBDKIT_REPO_URL   git URL of the nbdkit source (default: upstream GitLab)
+  NBDKIT_GIT_REF    git tag/branch to build (default: v<installed version>)
+  NBDKIT_BUILD_DIR  build directory (default: mktemp -d, removed on exit)
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force) FORCE="yes"; shift ;;
+        --no-verify) VERIFY="no"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage; die "unknown option: $1" ;;
+    esac
+done
+
+[ "$(id -u)" -eq 0 ] || die "this script must be run as root"
+command -v apt-get >/dev/null 2>&1 || \
+    die "apt-get not found: only Debian/Ubuntu migration hosts are supported (on RHEL install the nbdkit-vddk-plugin package instead)"
+
+# Make sure nbdkit itself is installed, then locate its plugindir
+if ! command -v nbdkit >/dev/null 2>&1; then
+    echo "Installing nbdkit..."
+    apt-get update || \
+        echo "WARNING: apt-get update failed, continuing with cached package lists"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nbdkit \
+        || die "failed to install nbdkit"
+fi
+
+plugindir=$(nbdkit --dump-config 2>/dev/null | sed -n 's/^plugindir=//p') \
+    || die "nbdkit --dump-config failed (nbdkit installed but non-functional?)"
+[ -n "$plugindir" ] || die "could not determine nbdkit's plugindir"
+mkdir -p "$plugindir"
+
+echo "nbdkit plugindir: $plugindir"
+
+if [ "$FORCE" = "no" ] && [ -f "$plugindir/$PLUGIN_NAME" ]; then
+    echo "Already configured. Use --force to redo the setup."
+    exit 0
+fi
+
+# Build dependencies
+echo "Installing build dependencies..."
+# non-fatal on purpose: cached package lists are usually good enough
+apt-get update || \
+    echo "WARNING: apt-get update failed, continuing with cached package lists"
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential git autoconf automake libtool pkg-config \
+    || die "failed to install build dependencies"
+
+# Build nbdkit from the sources matching the installed distro package
+installed_version=$(dpkg-query -W -f='${source:Upstream-Version}' nbdkit 2>/dev/null || true)
+git_ref="${NBDKIT_GIT_REF:-v$installed_version}"
+[ "$git_ref" != "v" ] || \
+    die "could not detect the installed nbdkit version; set NBDKIT_GIT_REF"
+
+if [ -n "${NBDKIT_BUILD_DIR:-}" ]; then
+    build_dir="$NBDKIT_BUILD_DIR"
+    mkdir -p "$build_dir"
+else
+    build_dir=$(mktemp -d)
+    trap 'rm -rf "$build_dir"' EXIT
+fi
+
+echo "Building nbdkit $git_ref in $build_dir..."
+src_dir="$build_dir/nbdkit"
+rm -rf "$src_dir"
+git clone --depth 1 --branch "$git_ref" "$REPO_URL" "$src_dir" || \
+    die "git clone of ref $git_ref failed; set NBDKIT_GIT_REF to a valid nbdkit tag/branch"
+cd "$src_dir"
+autoreconf -fi
+./configure --disable-dependency-tracking
+make -j"$(nproc)"
+built_plugin="$src_dir/plugins/vddk/.libs/$PLUGIN_NAME"
+[ -f "$built_plugin" ] || die "build finished but $built_plugin is missing"
+
+# Install only the plugin into the distro plugindir (no 'make install')
+echo "Installing $PLUGIN_NAME into $plugindir..."
+# stage next to the destination so the final rename is atomic (same filesystem)
+install -m 0644 "$built_plugin" "$plugindir/.$PLUGIN_NAME.tmp"
+mv "$plugindir/.$PLUGIN_NAME.tmp" "$plugindir/$PLUGIN_NAME"
+
+# Verification
+if [ "$VERIFY" = "yes" ]; then
+    nbdkit vddk --dump-plugin >/dev/null \
+        || die "verification failed: 'nbdkit vddk --dump-plugin' returned an error"
+    echo "OK: the VDDK plugin is installed and loadable by nbdkit."
+fi
+
+echo
+echo "Done. VDDK-based transfers (--vddk) can now be used on this host."

--- a/scripts/setup_ntfs_wof.sh
+++ b/scripts/setup_ntfs_wof.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2026, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# setup_ntfs_wof.sh
+#
+# One-time, idempotent setup that lets virt-v2v (and therefore OneSwap) read
+# CompactOS / WOF-compressed NTFS partitions during Windows VM conversions.
+#
+# It builds the ntfs-3g-system-compression plugin, installs it for the
+# host's ntfs-3g, and packs it as a supermin.d overlay so every libguestfs
+# appliance rebuild automatically includes it. No fixed appliance and no
+# LIBGUESTFS_PATH are needed; the setup survives /var/tmp/.guestfs-* wipes.
+
+set -euo pipefail
+
+REPO_URL="${NTFS_WOF_REPO_URL:-https://github.com/ebiggers/ntfs-3g-system-compression.git}"
+PLUGIN_NAME="ntfs-plugin-80000017.so"
+OVERLAY_NAME="zz-ntfs-wof.tar.gz"
+FORCE="no"
+VERIFY="yes"
+
+usage() {
+    cat <<'EOF'
+Usage: setup_ntfs_wof.sh [--force] [--no-verify] [-h|--help]
+
+Enables CompactOS (WOF-compressed NTFS) support for Windows VM conversions.
+Run once, as root, on the migration host.
+
+Options:
+  --force      redo the setup even if it looks already configured
+  --no-verify  skip the appliance rebuild + verification step
+  -h, --help   show this help
+
+Environment overrides:
+  NTFS_WOF_REPO_URL   git URL of the plugin source (default: upstream GitHub)
+  NTFS_WOF_BUILD_DIR  build directory (default: mktemp -d, removed on exit)
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force) FORCE="yes"; shift ;;
+        --no-verify) VERIFY="no"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage; die "unknown option: $1" ;;
+    esac
+done
+
+[ "$(id -u)" -eq 0 ] || die "this script must be run as root"
+command -v apt-get >/dev/null 2>&1 || \
+    die "apt-get not found: only Debian/Ubuntu migration hosts are supported"
+
+# Locate the supermin input dir and derive the ntfs-3g plugin dir from it
+supermin_dir=$(ls -d /usr/lib/*/guestfs/supermin.d 2>/dev/null | head -n 1 || true)
+[ -n "$supermin_dir" ] || \
+    die "supermin.d not found: install virt-v2v / libguestfs-tools first"
+
+libdir=${supermin_dir%/guestfs/supermin.d}
+plugin_dir="$libdir/ntfs-3g"
+
+echo "ntfs-3g plugin dir: $plugin_dir"
+echo "supermin input dir: $supermin_dir"
+
+if [ "$FORCE" = "no" ] && [ -f "$plugin_dir/$PLUGIN_NAME" ] \
+       && [ -f "$supermin_dir/$OVERLAY_NAME" ]; then
+    echo "Already configured. Use --force to redo the setup."
+    exit 0
+fi
+
+# Build dependencies
+echo "Installing build dependencies..."
+# non-fatal on purpose: cached package lists are usually good enough
+apt-get update || \
+    echo "WARNING: apt-get update failed, continuing with cached package lists"
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential git pkg-config autoconf automake libtool \
+    ntfs-3g-dev ntfs-3g libguestfs-tools \
+    || die "failed to install build dependencies"
+
+# Build the plugin from source
+if [ -n "${NTFS_WOF_BUILD_DIR:-}" ]; then
+    build_dir="$NTFS_WOF_BUILD_DIR"
+    mkdir -p "$build_dir"
+else
+    build_dir=$(mktemp -d)
+    trap 'rm -rf "$build_dir"' EXIT
+fi
+
+echo "Building ntfs-3g-system-compression in $build_dir..."
+src_dir="$build_dir/ntfs-3g-system-compression"
+rm -rf "$src_dir"
+git clone "$REPO_URL" "$src_dir" || die "git clone failed: $REPO_URL"
+cd "$src_dir"
+autoreconf -i
+./configure --libdir="$libdir"
+make
+make install
+[ -f "$plugin_dir/$PLUGIN_NAME" ] || \
+    die "build finished but $plugin_dir/$PLUGIN_NAME is missing"
+echo "Plugin installed: $plugin_dir/$PLUGIN_NAME"
+
+# supermin.d overlay so every appliance rebuild includes the plugin
+echo "Creating supermin overlay $supermin_dir/$OVERLAY_NAME..."
+overlay_root="$build_dir/overlay"
+mkdir -p "$overlay_root$plugin_dir"
+install -m 0644 "$plugin_dir/$PLUGIN_NAME" "$overlay_root$plugin_dir/$PLUGIN_NAME"
+tar -C "$overlay_root" --owner=0 --group=0 -czf "$build_dir/$OVERLAY_NAME" \
+    "${plugin_dir#/}"
+# stage next to the destination so the final rename is atomic (same filesystem)
+cp "$build_dir/$OVERLAY_NAME" "$supermin_dir/.$OVERLAY_NAME.tmp"
+mv "$supermin_dir/.$OVERLAY_NAME.tmp" "$supermin_dir/$OVERLAY_NAME"
+echo "Overlay installed; the cached appliance rebuilds automatically on next use."
+
+# Verification
+if [ "$VERIFY" = "yes" ]; then
+    command -v guestfish >/dev/null 2>&1 || \
+        die "guestfish not found, cannot verify (rerun with --no-verify to skip)"
+    echo "Rebuilding the libguestfs appliance (this can take a minute)..."
+    # -a /dev/null is a placeholder disk: launching any guestfs handle forces
+    # supermin to rebuild the cached appliance with the new overlay included
+    guestfish -a /dev/null run || die "appliance rebuild failed"
+
+    # libguestfs caches the appliance under LIBGUESTFS_CACHEDIR (default /var/tmp)
+    appliance_root=""
+    for cache_dir in "${LIBGUESTFS_CACHEDIR:-}" "${TMPDIR:-}" /var/tmp; do
+        [ -n "$cache_dir" ] || continue
+        if [ -f "$cache_dir/.guestfs-0/appliance.d/root" ]; then
+            appliance_root="$cache_dir/.guestfs-0/appliance.d/root"
+            break
+        fi
+    done
+    [ -n "$appliance_root" ] || \
+        die "could not locate the rebuilt appliance root image (.guestfs-0/appliance.d/root)"
+
+    plugin_listing=$(guestfish --ro -a "$appliance_root" -m /dev/sda ls "$plugin_dir" 2>&1) \
+        || die "guestfish failed to inspect the appliance image: $plugin_listing"
+    echo "$plugin_listing" | grep -q "$PLUGIN_NAME" \
+        || die "verification failed: $PLUGIN_NAME not found inside the appliance"
+    echo "OK: $PLUGIN_NAME is present inside the libguestfs appliance."
+fi
+
+echo
+echo "Done. Windows guests using CompactOS can now be converted on this host."


### PR DESCRIPTION
### Description

Windows guests using CompactOS (WOF-compressed NTFS) fail virt-v2v inspection ("No root device found") because the libguestfs appliance's ntfs-3g cannot read WOF reparse points. Separately, `--vddk` transfers fail on Debian/Ubuntu because the distro nbdkit package does not ship the VDDK plugin.

This PR makes both work without manual host setup:
- `scripts/setup_ntfs_wof.sh` - one-time idempotent host setup: builds the ntfs-3g-system-compression plugin and injects it into the libguestfs appliance via a supermin.d overlay
- `scripts/setup_nbdkit_vddk.sh` - builds the nbdkit VDDK plugin from the tag matching the installed distro package and installs only the plugin .so
- Prechecks: warning for Windows guests when WOF support is missing; hard fail with an actionable message when `--vddk` is used without the nbdkit plugin
- `handle_v2v_error`: actionable hints for the CompactOS inspection failure and the missing VDDK plugin
- README: System Requirements row for nbdkit + "Windows CompactOS Support" and "VDDK Transfer Support" sections

Tested end-to-end on Ubuntu 24.04: both setup scripts ran successfully and a Windows 10 guest with `compactos:always` converts after setup.

<!--- Please leave a helpful description of the PR here. --->

Test status:
```
root@ubuntu2404-18:~# /usr/bin/oneswap convert oneswap-w10-test --vddk /opt/vmware-vix-disklib-distrib/ --format qcow2 --root first --one-cluster 0 --skip-ip --skip-mac --persistent-img --delete-after --work-dir /var/tmp --virtio /usr/share/virtio-win/virtio-win.iso --win-qemu-ga /usr/share/virtio-win/guest-agent/qemu-ga-x86_64.msi --remove-vmtools $VOPTS
Running OpenNebula prechecks...
Certificate thumbprint: 09:77:5b:0e:94:b0:81:ae:9e:a6:c6:a3:51:01:34:58:20:b2:24:b0
Running: virt-v2v -v --machine-readable -ic 'vpx://oneswap%40vsphere.local@vcenter/Datacenter/OpenNebula_Cluster/esxi?no_verify=1' -ip /var/tmp/oneswap-w10-test/vpassfile -it vddk -io vddk-libdir=/opt/vmware-vix-disklib-distrib/ -io vddk-thumbprint=09:77:5b:0e:94:b0:81:ae:9e:a6:c6:a3:51:01:34:58:20:b2:24:b0 -o local -os /var/tmp/oneswap-w10-test/conversions/ -of qcow2 'oneswap-w10-test'

Setting up the source: -i libvirt -ic vpx://oneswap%40vsphere.local@vcenter/Datacenter/OpenNebula_Cluster/esxi?no_verify=1 -it vddk oneswap-w10-test..
Opening the source......................................................................
Inspecting the source
Inspecting guest OS.................................................................................
Checking for sufficient free disk space in the guest
Converting Windows 10 Pro to run on KVM, this may take a long time...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
This guest has virtio drivers installed..
Mapping filesystem data to avoid copying unused and blank areas
Inspecting filesystems, this can take several minutes.....................
Closing the overlay....
Assigning disks to buses
Checking if the guest needs BIOS or UEFI to boot
This guest requires UEFI on the target to boot.
Setting up the destination: -o disk -os /var/tmp/oneswap-w10-test/conversions/.........
Copying disk 1/1, this may take a long time

Creating output metadata
Finishing off
1 disks on the local disk for this VM: ["/var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda"]
Creating Images in OpenNebula
Inspecting disk...Done (9.89s)
Injecting one-context...Running: virt-customize -q -a /var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda --mkdir /Temp --copy-in /usr/share/one/context/one-context-7.2.0-0.msi:/Temp --firstboot-command 'msiexec -i c:\Temp\one-context-7.2.0-0.msi /quiet && del c:\Temp\one-context-7.2.0-0.msi'
Success (10.09s)
win_virtio_command cmd: virt-customize -a /var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda --inject-virtio-win /usr/share/virtio-win/virtio-win.iso
Injecting VirtIO to Windows...Running: virt-customize -a /var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda --inject-virtio-win /usr/share/virtio-win/virtio-win.iso
Success (28.82s)
Injecting QEMU Guest Agent...Running: virt-customize -a /var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda --mkdir /Temp --copy-in /usr/share/virtio-win/guest-agent/qemu-ga-x86_64.msi:/Temp --firstboot-command 'msiexec /i c:\Temp\qemu-ga-x86_64.msi /quiet /norestart && del c:\Temp\qemu-ga-x86_64.msi'
Success (10.9s)
Starting VMWare Tools Removal script injection...
Running: virt-customize -q -a /var/tmp/oneswap-w10-test/conversions/oneswap-w10-test-sda --mkdir /Temp --copy-in /usr/lib/one/oneswap/scripts/vmware_tools_removal.ps1:/Temp --firstboot-command 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "sc config VMTools start=disabled; sc config VGAuthService start=disabled; sc stop VMTools; sc stop VGAuthService" 2>$null' --firstboot-command 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File C:\Temp\vmware_tools_removal.ps1'
Success (11.33s)
Disabling VMware Tools services in offline registry...
VMware Tools services disabled (virt-win-reg)
VMware Tools removal script staged for first boot. Check the guest log if removal fails.
Allocating image 0 in OpenNebula
Waiting for image to be ready. Timeout: 120 seconds.
Allocated images in OpenNebula in (206.96s)
Created images: [{:id=>1, :os=>"windows"}]
Allocating the VM template...Success
VM Template ID: 1
Deleting password files.
Deleting vdisks in /var/tmp/oneswap-w10-test/conversions
Deleting everything in and including /var/tmp/oneswap-w10-test
```


### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
