### PR TITLE
B #826: [OneSwap] Fix the -v/--verbose flag

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -780,7 +780,7 @@ CommandParser::CmdParser.new(ARGV) do
                 puts "Unable to find the config file at #{options[:config_file]}"
             end
 
-            options[:config_file] ||= '/var/lib/one/oneswap.yaml'
+            options[:config_file] ||= '/etc/one/oneswap.yaml'
             cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
             options.merge!(cfg_file) if cfg_file
 

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -56,6 +56,9 @@
 #:uefi_path: '/usr/share/OVMF/OVMF_CODE.fd'                 # Path to the UEFI file to be configured in the VM template.
 #:uefi_sec_path: '/usr/share/OVMF/OVMF_CODE.secboot.fd'     # Path to the UEFI Secure file to be configured in the VM template.
 
+# Logging Options
+#:verbose: true                           # Verbose mode: log at DEBUG and echo diagnostics to the terminal (STDERR) as well as /var/log/one/oneswap.log. Equivalent to the -v/--verbose flag or the ONE_SWAP_DEBUG env var. Note: like every option here, an uncommented value takes precedence over the command line.
+
 # OpenNebula Placement Options
 #:one_cluster:                            # ID of the OpenNebula Cluster
 #:one_host:                               # ID of the OpenNebula Host

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -24,6 +24,7 @@ require 'tmpdir'
 require_relative 'vsphere_client'
 require_relative 'esxi_vm'
 require_relative 'windows_tuner'
+require_relative 'oneswap_logger'
 
 class String
 
@@ -142,10 +143,25 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
 
         Dir.mkdir(ONE_LOGS) unless Dir.exist?(ONE_LOGS)
 
-        log_level = ENV['ONE_SWAP_DEBUG'].nil? ? 'INFO' : 'DEBUG'
+        @log_file = File.open(LOG, 'a')
+        @log_file.sync = true
 
-        @logger = Logger.new(LOG)
-        @logger.level = Logger.const_get(log_level)
+        @verbose = OneSwapLogger.verbose?({})
+        @logger  = OneSwapLogger.build(@log_file, :verbose => @verbose)
+    end
+
+    # Raise log verbosity to DEBUG (and echo diagnostics to the terminal, not
+    # just the oneswap log file) when verbose mode is requested through any
+    # channel: the -v/--verbose CLI flag, a ":verbose: true" entry in
+    # oneswap.yaml, or the ONE_SWAP_DEBUG env var. 
+    #
+    # @param options [Hash] CLI options, already merged with the config file
+    def apply_verbosity(options)
+        return if @verbose
+        return unless OneSwapLogger.verbose?(options)
+
+        @verbose = true
+        @logger  = OneSwapLogger.build(@log_file, :verbose => true)
     end
 
     @props, @options = []
@@ -2620,6 +2636,7 @@ GUESTFISH
     # @param options [Hash] User CLI options
     # @param object  [Hash] Object Type
     def list(options)
+        apply_verbosity(options)
         case options[:object]
         when 'datacenters'
             list_datacenters(options)
@@ -2637,6 +2654,7 @@ GUESTFISH
     # @param name    [Hash] Object Name
     # @param options [Hash] User CLI options
     def convert(name, options)
+        apply_verbosity(options)
         check_one_connectivity
         if !Dir.exist?(options[:work_dir])
             raise 'Provided working directory '\
@@ -2752,6 +2770,7 @@ GUESTFISH
     # @param name    [Hash] Object Name
     # @param options [Hash] User CLI options
     def import(options)
+        apply_verbosity(options)
         source = options[:ova] || options[:vmdk]
         name = File.basename(source, File.extname(source))
         check_one_connectivity

--- a/oneswap_logger.rb
+++ b/oneswap_logger.rb
@@ -1,0 +1,85 @@
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2026, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+require 'logger'
+
+# Logging helpers for oneswap.
+
+module OneSwapLogger
+
+    class MultiIO
+
+        def initialize(*targets)
+            @targets = targets
+        end
+
+        def write(*args)
+            errors = []
+            @targets.each do |t|
+                begin
+                    t.write(*args)
+                rescue StandardError => e
+                    errors << e
+                end
+            end
+
+            raise errors.first if errors.any? && errors.size == @targets.size
+        end
+
+        def close
+            @targets.each do |t|
+                next if [$stdout, $stderr, STDOUT, STDERR].any? {|s| t.equal?(s) }
+
+                t.close
+            end
+        end
+
+    end
+
+    # Resolve whether verbose/diagnostic logging should be enabled.
+    #
+    # Verbose mode can be requested through any of three equivalent channels:
+    #   * the -v/--verbose CLI flag, and
+    #   * a ":verbose: true" entry in oneswap.yaml
+    #     (both end up in options[:verbose] after the config file is merged), or
+    #   * the ONE_SWAP_DEBUG environment variable (any value, even "").
+    #
+    # @param options [Hash] CLI options, already merged with the config file
+    # @param env     [Hash] environment (injectable for tests)
+    # @return [Boolean]
+    def self.verbose?(options, env = ENV)
+        !!(options[:verbose] || !env['ONE_SWAP_DEBUG'].nil?)
+    end
+
+    # Build a Logger for oneswap.
+    #
+    # In verbose mode it logs at DEBUG and echoes every line to the terminal
+    # (STDERR) in addition to the log file
+    #
+    # @param log_file [IO]      open, writable log file device
+    # @param verbose  [Boolean] whether verbose/debug logging is enabled
+    # @param stderr   [IO]      terminal stream for the verbose echo
+    #                           (injectable so it can be exercised in tests)
+    # @return [Logger]
+    def self.build(log_file, verbose:, stderr: STDERR)
+        device = verbose ? MultiIO.new(log_file, stderr) : log_file
+
+        logger = Logger.new(device)
+        logger.level = verbose ? Logger::DEBUG : Logger::INFO
+        logger
+    end
+
+end


### PR DESCRIPTION
### Description

Changes:
- **`-v`/`--verbose`, `:verbose:` key in `oneswap.yaml` and `ONE_SWAP_DEBUG`** env variable now all of them enable verbose mode. In verbose mode the logger drops to `DEBUG` and echoes every line to the terminal (STDERR) in addition to the log file
- added `oneswap_logger.rb` module:
  - `MultiIO` - a tee so a single `Logger` can write to both the log file and the terminal, it writes the log file first
  - `verbose?` - resolves the verbose state from options + env
  - `build` - constructs the configured `Logger`
- aligned **`import`** config file default to `/etc/one/oneswap.yaml` (previously used `/var/lib/one/oneswap.yaml`)

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
