### PR TITLE
F #7712: Add striped hybrid vdisk downloads

### DIFF
--- a/oneswap
+++ b/oneswap
@@ -401,6 +401,13 @@ CommandParser::CmdParser.new(ARGV) do
         :description => 'Download the disk using rbvmomi2, then convert the vm using virt-v2v locally.'
     }
 
+    DOWNLOAD_STRIPES = {
+        :name => 'download_stripes',
+        :large => '--download-stripes N',
+        :description => 'Parallel HTTP range downloads for hybrid datastore transfers only. Default: 1',
+        :format => Integer
+    }
+
     WIN_GA = {
         :name => 'qemu_ga_win',
         :large => '--win-qemu-ga /path/to/iso',
@@ -585,7 +592,7 @@ CommandParser::CmdParser.new(ARGV) do
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
@@ -677,6 +684,10 @@ CommandParser::CmdParser.new(ARGV) do
             cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
             options.merge!(cfg_file) if cfg_file
 
+            if (options[:download_stripes] || 1).to_i > 1 && !options[:hybrid]
+                raise '--download-stripes N > 1 requires --hybrid.'
+            end
+
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
             raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk_path]
             if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])
@@ -712,6 +723,7 @@ CommandParser::CmdParser.new(ARGV) do
             options[:skip_prechecks]   ||= false
             options[:context_min_free] ||= 1024
             options[:context_timeout]  ||= 600
+            options[:download_stripes] ||= 1
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|

--- a/oneswap.1
+++ b/oneswap.1
@@ -76,6 +76,9 @@
                            separate oneswap server
  \-\-hybrid                  Download the disk using rbvmomi2, then convert
                            the vm using virt\-v2v locally\.
+ \-\-download\-stripes N     Parallel HTTP range downloads for hybrid datastore
+                           transfers only\. Requires \-\-hybrid when N > 1\.
+                           Default: 1
  \-\-img\-wait sec            The amount of time to wait in seconds for the
                            image to be created in OpenNebula\. Default is
                            120 seconds
@@ -178,7 +181,7 @@ Examples:
     You can also define \-\-fallback instead of \-\-custom, which will first attempt virt\-v2v style, then fallback to custom\.
 
     oneswap convert vm\-1234 $VOPTS \-\-custom
-valid options: accept_cert, clone, config_file, context, context_fail_on_low_space, context_min_free, context_timeout, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, inject_dns, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
+valid options: accept_cert, clone, config_file, context, context_fail_on_low_space, context_min_free, context_timeout, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, download_stripes, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, inject_dns, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
 .
 .fi
 .

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -19,6 +19,10 @@
 #:custom_convert:                         # Uses OpenNebula's custom conversion process, useful for distributions which are not supported or fail to convert
 #:fallback:                               # Fallback to OpenNebula's custom conversion process
 #:hybrid:                                 # Transfer using rbvmomi2's download, then convert with virt-v2v locally
+# Number of parallel HTTP Range downloads used by hybrid datastore transfers.
+# Applies only to --hybrid mode. Default is 1, which preserves the existing
+# single-stream download behavior.
+#:download_stripes: 1
 #:img_wait:                               # Amount of time to wait in seconds for image to be created in OpenNebula, default: 120
 
 # Import Options

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2105,7 +2105,7 @@ _EOF_"
             end
 
             local_file = @options[:work_dir] + '/transfers/' + @props['name'] + "-disk#{i}.vmdk"
-            d[:backing][:datastore].download(remote_file, local_file)
+            hybrid_datastore_download(d[:backing][:datastore], remote_file, local_file)
             local_disks.append(local_file)
         end
 
@@ -2116,6 +2116,103 @@ _EOF_"
         puts "Downloaded disks from vCenter storage to local disk in (#{(Time.now - t0).round(2)}s)".green
 
         local_disks
+    end
+
+    def hybrid_datastore_download(datastore, remote_file, local_file)
+        stripes = (@options[:download_stripes] || 1).to_i
+        return datastore.download(remote_file, local_file) if stripes <= 1
+
+        http = datastore._connection.http
+        scheme = http.use_ssl? ? 'https' : 'http'
+        url = "#{scheme}://#{http.address}:#{http.port}" \
+              "#{datastore.send(:mkuripath, remote_file)}"
+        cookie = datastore._connection.cookie.to_s
+        headers_file = Tempfile.new('oneswap-range-headers')
+        probe_file = Tempfile.new('oneswap-range-probe')
+        headers_file.close
+        probe_file.close
+
+        probe_ok = system('curl', '-k', '--noproxy', '*', '-f',
+                          '-r', '0-1048575', '-D', headers_file.path,
+                          '--max-filesize', '1048576',
+                          '-o', probe_file.path, '-b', cookie, url)
+        content_range = File.read(headers_file.path).scan(
+            /^content-range:\s*bytes\s+0-(\d+)\/(\d+)\s*$/i
+        ).last
+
+        probe_end = content_range && content_range[0].to_i
+        remote_size = content_range && content_range[1].to_i
+        probe_size = File.size(probe_file.path)
+        valid_range = remote_size && remote_size > 0 &&
+                      probe_end == [1048575, remote_size - 1].min &&
+                      probe_size == [1048576, remote_size].min
+
+        unless probe_ok && valid_range
+            puts 'HTTP Range unsupported; using single-stream hybrid download'
+            return datastore.download(remote_file, local_file)
+        end
+
+        if stripes > remote_size
+            raise "Unable to split #{remote_size} bytes into #{stripes} download stripes."
+        end
+
+        ranges = stripes.times.map do |i|
+            first = (remote_size * i) / stripes
+            last = ((remote_size * (i + 1)) / stripes) - 1
+            [first, last]
+        end
+        part_files = ranges.each_index.map {|i| "#{local_file}.part#{i}" }
+
+        puts "Using striped hybrid download (#{stripes} stripes)"
+        ranges.each_with_index do |range, i|
+            puts "Stripe #{i}: bytes #{range[0]}-#{range[1]}"
+        end
+
+        pids = []
+        begin
+            ranges.each_with_index do |range, i|
+                pids << Process.spawn('curl', '-k', '--noproxy', '*', '-f',
+                                      '-r', "#{range[0]}-#{range[1]}",
+                                      '-o', part_files[i], '-b', cookie, url)
+            end
+            failed = []
+            pids.each_with_index do |pid, i|
+                _waited_pid, status = Process.wait2(pid)
+                failed << i unless status.success?
+            end
+
+            unless failed.empty?
+                raise "Striped hybrid download failed for stripe(s): #{failed.join(', ')}."
+            end
+
+            # TODO: Write ranges into a preallocated output file by offset to
+            # avoid temporary double disk usage.
+            File.open(local_file, 'wb') do |output|
+                part_files.each do |part_file|
+                    File.open(part_file, 'rb') do |part|
+                        IO.copy_stream(part, output)
+                    end
+                end
+            end
+
+            assembled_size = File.size(local_file)
+            if assembled_size != remote_size
+                FileUtils.rm_f(local_file)
+                raise "Striped hybrid download size mismatch: expected #{remote_size}, " \
+                      "got #{assembled_size}."
+            end
+        ensure
+            pids.each do |pid|
+                Process.wait(pid)
+            rescue Errno::ECHILD
+                nil
+            end
+            FileUtils.rm_f(part_files)
+        end
+        puts "Assembled striped hybrid download (#{assembled_size} bytes)"
+    ensure
+        headers_file&.unlink
+        probe_file&.unlink
     end
 
     def build_hybrid_xml(disks)


### PR DESCRIPTION
### Description

Add optional striped downloads for OneSwap hybrid datastore transfers.

This adds `--download-stripes N` for `oneswap convert --hybrid`.

Behavior:

* Default remains `1`, preserving the existing single-stream `datastore.download(...)` path.
* `--download-stripes N > 1` requires `--hybrid`.
* For hybrid datastore downloads, OneSwap probes HTTP Range support with a guarded 1 MiB request.
* If Range support is unavailable or invalid, it falls back to the existing single-stream download.
* If supported, it downloads byte ranges in parallel, assembles the VMDK in order, validates final size, and cleans temporary part files.

Tested on the testbed:

* `--download-stripes 4` without `--hybrid` fails early as expected.
* `--hybrid --download-stripes 4` completed striped VMDK download.
* Final assembled VMDK size: `21474836480` bytes.
* Download time: `341.38s`.

Previous single-stream baseline:

* `500.51s`.

Result:

* Around 31.8% faster download phase in this test.

The later `libguestfs/supermin` failure happens after the download phase and also occurs without `--download-stripes`, so it is unrelated to this change.

### Branches to which this PR applies

- [x] master
- [x] one-7.2