### PR TITLE
F #7474: OneSwap dry-run estimation for regular and staged delta migrations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,155 +68,48 @@ variable.
 
 ## Dry-run Estimates
 
-To estimate a regular conversion without running the migration:
+OneSwap can estimate migration time without running the full conversion. Dry-run
+reports estimate basis, rates, phase durations, and confidence.
+
+Regular dry-run:
 
 ```
 oneswap convert <vm> --dry-run
 ```
 
-This reads VM and disk metadata, estimates export, qcow2 conversion, and
-OpenNebula import time. It reports estimate basis, rates, phase durations, and
-confidence. Source export and conversion use configured fallback values unless
-matching regular conversion metrics are available. Target import can reuse
-matching previous OpenNebula import metrics or a benchmark metric for the
-current transfer mode. Without `--benchmark-import`, it does not create VMware
-snapshots, OpenNebula images, or OpenNebula templates, and it does not modify
-the source VM.
-
-To benchmark the OpenNebula image import path before a regular dry-run:
+Optional OpenNebula import benchmark:
 
 ```
 oneswap convert <vm> --dry-run --benchmark-import
 ```
 
-With `http_transfer` enabled, this creates a temporary non-sparse raw test
-file, imports it as a temporary OpenNebula image, records the measured import
-rate, deletes the temporary image/file, and then runs the dry-run estimate.
-When `http_transfer` is disabled, local-path benchmarking is skipped; the
-estimate uses matching local-path full import metrics or
-`dry_run_target_import_mib_s`.
+`--benchmark-import` measures the OpenNebula image import path using a
+temporary image and stores transfer-mode-specific metrics for future estimates.
 
 ### Delta Dry-run Workflow
 
-For delta migrations, you can stage the online base phase first:
+Staged delta migration can prepare the base disks while the source VM keeps
+running, estimate the final phase, and then commit during the downtime window.
 
 ```
 oneswap convert <vm> --delta --delta-prepare
-```
-
-This creates a VMware snapshot while the source VM keeps running, then
-clones, transfers, and converts the base disks. It writes prepared state under
-the VM work directory and does not shut down the VM, apply the final delta, or
-create OpenNebula images/templates. The VMware snapshot remains active after
-prepare, so the delta can continue growing.
-
-Then estimate downtime from the prepared state:
-
-```
 oneswap convert <vm> --dry-run --delta
-```
-
-This reads the prepared state, checks the current snapshot delta extent size
-on ESXi, and estimates the final downtime/import-ready phase. It reports the
-current delta copy estimate, delta apply estimate, OpenNebula image import/copy
-estimate, virt-v2v-in-place / OS morph estimate, guest customization estimate,
-and template creation as negligible. When available, it prefers measured base
-transfer/conversion throughput stored during prepare and measured OpenNebula
-import/customization metrics from previous runs. If that data is missing, it
-falls back to configured values such as `dry_run_target_import_mib_s`,
-`dry_run_delta_os_morph_seconds`, and
-`dry_run_guest_customization_seconds`. Set `dry_run_target_import_mib_s` to
-match the full OpenNebula frontend/datastore import path, not only network
-bandwidth.
-
-Each delta dry-run refreshes the live snapshot extent size from ESXi using the
-prepared state. If that refresh fails, OneSwap warns and falls back to the
-prepare-time stored value with lower confidence.
-
-The delta dry-run report includes an estimate basis section showing whether
-each phase comes from prepare measurements, an import benchmark, previous full
-import metrics, or configured fallbacks. Confidence is `high` when prepare
-transfer/conversion are measured and target import comes from a previous full
-import or a benchmark of at least 4 GiB, and OS morph/customization timings
-come from a previous successful run. It is `medium` when prepare metrics are
-available but target import uses configured fallback or a small benchmark, or
-when OS morph/customization still use configured fallback values. It is `low`
-when prepare metrics are missing or an important phase cannot be accounted for.
-
-To measure the OpenNebula frontend/datastore import path before commit, run:
-
-```
 oneswap convert <vm> --dry-run --delta --benchmark-import
-```
-
-This requires prepared delta state from `--delta --delta-prepare`. When
-`http_transfer` is enabled, OneSwap creates a temporary non-sparse raw test
-file under the VM work directory, serves it through the configured
-`http_host`/`http_port`, allocates a temporary OpenNebula image, waits for it
-to become `READY`, records the measured import rate in the VM metrics file,
-deletes the temporary image, and then runs the normal delta dry-run estimate.
-The test file size defaults to `dry_run_import_benchmark_size_mib: 4096` and
-is configurable. Small benchmark files can be dominated by fixed OpenNebula
-allocation, datastore, and polling overhead, so files below 1024 MiB are
-reported with a warning and can produce pessimistic linear estimates. If a
-previous full import metric is available, it is preferred over a small
-benchmark because it is more representative. If the benchmark cannot run or
-fails, the estimate falls back to previous import metrics or
-`dry_run_target_import_mib_s`.
-
-Import metrics are transfer-mode specific. HTTP benchmark/import metrics are
-used only when the current run has `http_transfer` enabled; local-path imports
-use local-path metrics or the configured fallback. This avoids applying a
-previous HTTP measurement to a commit that will allocate images from local
-filesystem paths.
-
-If you want to continue immediately, run the downtime phase:
-
-```
 oneswap convert <vm> --delta --delta-commit
-```
-
-This shuts down the source VM, copies and applies the remaining delta, and
-then creates OpenNebula images/templates through the existing migration flow.
-This is the real migration completion step, not a dry-run. If OneSwap runs on
-a worker host that is not the OpenNebula frontend, enable `http_transfer` and
-set `http_host`/`http_port` so the frontend can fetch the committed disk files
-over HTTP instead of trying to read worker-local paths.
-
-When `http_transfer` is disabled, OpenNebula image `PATH` values are local
-filesystem paths resolved by the OpenNebula frontend/oned host. In local PATH
-mode, run OneSwap on the OpenNebula frontend or make sure `work_dir` is shared
-at the same absolute path on the frontend. Delta commit preflights this before
-shutting down the source VM; if the OpenNebula endpoint appears remote, it
-aborts and preserves the prepared state. Use `http_transfer` for worker-host
-migrations, or pass `--allow-local-path-remote` only when the path is
-intentionally shared and visible to the frontend.
-
-If you only wanted timing data and will migrate later, clean up the prepared
-snapshot and state:
-
-```
 oneswap convert <vm> --delta --delta-cleanup
 ```
 
-This removes the VMware snapshot created by prepare, the temporary ESXi clone
-directory, and the local prepared transfer/conversion/state directory. Later,
-during the chosen maintenance window, run a normal full delta migration with
-the same backward-compatible command:
-
-```
-oneswap convert <vm> --delta
-```
-
-Delta migration discovers the ESXi host from vCenter `runtime.host`. ESXi SSH
-authentication tries passwordless SSH first, then uses `esxi_user`/`esxi_pass`
-from CLI options or `oneswap.yaml`, and finally falls back to a limited
-interactive prompt. A single `esxi_user`/`esxi_pass` pair applies to the
-discovered ESXi host; per-host credential mapping is not implemented.
+When OneSwap runs on a worker host, enable `http_transfer` so the OpenNebula
+frontend can fetch images over HTTP. Local-path mode requires OneSwap to run on
+the OpenNebula frontend, or `work_dir` to be shared at the same absolute path
+on the frontend.
 
 Do not leave the VMware snapshot created by `--delta --delta-prepare` active
 indefinitely. Either finish with `--delta --delta-commit` or run
 `--delta-cleanup` if aborting or postponing the migration.
+
+For detailed behavior, metric selection, confidence levels, and examples, see
+the official OpenNebula documentation.
 
 ## vCenter Permissions Requirements
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ OpenNebula templates, and it does not modify the source VM.
 
 ### Delta Dry-run Workflow
 
-For delta migrations, run the base phase first:
+For delta migrations, you can stage the online base phase first:
 
 ```
 oneswap convert <vm> --delta --delta-prepare
@@ -100,12 +100,50 @@ oneswap convert <vm> --dry-run --delta
 ```
 
 This reads the prepared state, checks the current snapshot delta extent size
-on ESXi, and estimates downtime from the current delta size. When available,
-it prefers the measured base transfer throughput stored during prepare; if
-that data is missing, it falls back to the configured dry-run throughput
-values.
+on ESXi, and estimates the final downtime/import-ready phase. It reports the
+current delta copy estimate, delta apply estimate, OpenNebula image import/copy
+estimate, virt-v2v-in-place / OS morph estimate, guest customization estimate,
+and template creation as negligible. When available, it prefers measured base
+transfer/conversion throughput stored during prepare and measured OpenNebula
+import/customization metrics from previous runs. If that data is missing, it
+falls back to configured values such as `dry_run_target_import_mib_s`,
+`dry_run_delta_os_morph_seconds`, and
+`dry_run_guest_customization_seconds`. Set `dry_run_target_import_mib_s` to
+match the full OpenNebula frontend/datastore import path, not only network
+bandwidth.
 
-Finally, run the downtime phase:
+The delta dry-run report includes an estimate basis section showing whether
+each phase comes from prepare measurements, an import benchmark, previous full
+import metrics, or configured fallbacks. Confidence is `high` when prepare
+transfer/conversion are measured and target import comes from a previous full
+import or a benchmark of at least 4 GiB, and OS morph/customization timings
+come from a previous successful run. It is `medium` when prepare metrics are
+available but target import uses configured fallback or a small benchmark, or
+when OS morph/customization still use configured fallback values. It is `low`
+when prepare metrics are missing or an important phase cannot be accounted for.
+
+To measure the OpenNebula frontend/datastore import path before commit, run:
+
+```
+oneswap convert <vm> --dry-run --delta --benchmark-import
+```
+
+This requires prepared delta state from `--delta --delta-prepare`. When
+`http_transfer` is enabled, OneSwap creates a temporary non-sparse raw test
+file under the VM work directory, serves it through the configured
+`http_host`/`http_port`, allocates a temporary OpenNebula image, waits for it
+to become `READY`, records the measured import rate in the VM metrics file,
+deletes the temporary image, and then runs the normal delta dry-run estimate.
+The test file size defaults to `dry_run_import_benchmark_size_mib: 4096` and
+is configurable. Small benchmark files can be dominated by fixed OpenNebula
+allocation, datastore, and polling overhead, so files below 1024 MiB are
+reported with a warning and can produce pessimistic linear estimates. If a
+previous full import metric is available, it is preferred over a small
+benchmark because it is more representative. If the benchmark cannot run or
+fails, the estimate falls back to previous import metrics or
+`dry_run_target_import_mib_s`.
+
+If you want to continue immediately, run the downtime phase:
 
 ```
 oneswap convert <vm> --delta --delta-commit
@@ -113,9 +151,22 @@ oneswap convert <vm> --delta --delta-commit
 
 This shuts down the source VM, copies and applies the remaining delta, and
 then creates OpenNebula images/templates through the existing migration flow.
+This is the real migration completion step, not a dry-run. If OneSwap runs on
+a worker host that is not the OpenNebula frontend, enable `http_transfer` and
+set `http_host`/`http_port` so the frontend can fetch the committed disk files
+over HTTP instead of trying to read worker-local paths.
 
-For backward compatibility, the original command still performs the full delta
-migration in one shot:
+If you only wanted timing data and will migrate later, clean up the prepared
+snapshot and state:
+
+```
+oneswap convert <vm> --delta --delta-cleanup
+```
+
+This removes the VMware snapshot created by prepare, the temporary ESXi clone
+directory, and the local prepared transfer/conversion/state directory. Later,
+during the chosen maintenance window, run a normal full delta migration with
+the same backward-compatible command:
 
 ```
 oneswap convert <vm> --delta
@@ -128,8 +179,8 @@ interactive prompt. A single `esxi_user`/`esxi_pass` pair applies to the
 discovered ESXi host; per-host credential mapping is not implemented.
 
 Do not leave the VMware snapshot created by `--delta --delta-prepare` active
-indefinitely. Either finish with `--delta --delta-commit` or remove/clean up
-the snapshot if aborting the migration.
+indefinitely. Either finish with `--delta --delta-commit` or run
+`--delta-cleanup` if aborting or postponing the migration.
 
 ## vCenter Permissions Requirements
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,16 @@ Optional OpenNebula import benchmark:
 oneswap convert <vm> --dry-run --benchmark-import
 ```
 
+Optional source export benchmark:
+
+```
+oneswap convert <vm> --dry-run --benchmark-export
+```
+
 `--benchmark-import` measures the OpenNebula image import path using a
-temporary image and stores transfer-mode-specific metrics for future estimates.
+temporary image. `--benchmark-export` creates a temporary file on the VM's
+source datastore and measures the VMware datastore download path. Both store
+mode-specific metrics for future estimates.
 
 ### Delta Dry-run Workflow
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,71 @@ and copies only the VDDK plugin into nbdkit's plugin directory. It requires
 internet access, or an internal mirror via the `NBDKIT_REPO_URL` environment
 variable.
 
+## Dry-run Estimates
+
+To estimate a regular conversion without running the migration:
+
+```
+oneswap convert <vm> --dry-run
+```
+
+This reads VM and disk metadata, estimates export, qcow2 conversion, and
+OpenNebula import time, and uses the configured fallback throughput values from
+`oneswap.yaml`. It does not create VMware snapshots, OpenNebula images, or
+OpenNebula templates, and it does not modify the source VM.
+
+### Delta Dry-run Workflow
+
+For delta migrations, run the base phase first:
+
+```
+oneswap convert <vm> --delta --delta-prepare
+```
+
+This creates a VMware snapshot while the source VM keeps running, then
+clones, transfers, and converts the base disks. It writes prepared state under
+the VM work directory and does not shut down the VM, apply the final delta, or
+create OpenNebula images/templates. The VMware snapshot remains active after
+prepare, so the delta can continue growing.
+
+Then estimate downtime from the prepared state:
+
+```
+oneswap convert <vm> --dry-run --delta
+```
+
+This reads the prepared state, checks the current snapshot delta extent size
+on ESXi, and estimates downtime from the current delta size. When available,
+it prefers the measured base transfer throughput stored during prepare; if
+that data is missing, it falls back to the configured dry-run throughput
+values.
+
+Finally, run the downtime phase:
+
+```
+oneswap convert <vm> --delta --delta-commit
+```
+
+This shuts down the source VM, copies and applies the remaining delta, and
+then creates OpenNebula images/templates through the existing migration flow.
+
+For backward compatibility, the original command still performs the full delta
+migration in one shot:
+
+```
+oneswap convert <vm> --delta
+```
+
+Delta migration discovers the ESXi host from vCenter `runtime.host`. ESXi SSH
+authentication tries passwordless SSH first, then uses `esxi_user`/`esxi_pass`
+from CLI options or `oneswap.yaml`, and finally falls back to a limited
+interactive prompt. A single `esxi_user`/`esxi_pass` pair applies to the
+discovered ESXi host; per-host credential mapping is not implemented.
+
+Do not leave the VMware snapshot created by `--delta --delta-prepare` active
+indefinitely. Either finish with `--delta --delta-commit` or remove/clean up
+the snapshot if aborting the migration.
+
 ## vCenter Permissions Requirements
 
 OneSwap requires specific vCenter permissions depending on the conversion mode used. Below are the required privileges for vCenter 8.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ falls back to configured values such as `dry_run_target_import_mib_s`,
 match the full OpenNebula frontend/datastore import path, not only network
 bandwidth.
 
+Each delta dry-run refreshes the live snapshot extent size from ESXi using the
+prepared state. If that refresh fails, OneSwap warns and falls back to the
+prepare-time stored value with lower confidence.
+
 The delta dry-run report includes an estimate basis section showing whether
 each phase comes from prepare measurements, an import benchmark, previous full
 import metrics, or configured fallbacks. Confidence is `high` when prepare
@@ -143,6 +147,12 @@ benchmark because it is more representative. If the benchmark cannot run or
 fails, the estimate falls back to previous import metrics or
 `dry_run_target_import_mib_s`.
 
+Import metrics are transfer-mode specific. HTTP benchmark/import metrics are
+used only when the current run has `http_transfer` enabled; local-path imports
+use local-path metrics or the configured fallback. This avoids applying a
+previous HTTP measurement to a commit that will allocate images from local
+filesystem paths.
+
 If you want to continue immediately, run the downtime phase:
 
 ```
@@ -155,6 +165,15 @@ This is the real migration completion step, not a dry-run. If OneSwap runs on
 a worker host that is not the OpenNebula frontend, enable `http_transfer` and
 set `http_host`/`http_port` so the frontend can fetch the committed disk files
 over HTTP instead of trying to read worker-local paths.
+
+When `http_transfer` is disabled, OpenNebula image `PATH` values are local
+filesystem paths resolved by the OpenNebula frontend/oned host. In local PATH
+mode, run OneSwap on the OpenNebula frontend or make sure `work_dir` is shared
+at the same absolute path on the frontend. Delta commit preflights this before
+shutting down the source VM; if the OpenNebula endpoint appears remote, it
+aborts and preserves the prepared state. Use `http_transfer` for worker-host
+migrations, or pass `--allow-local-path-remote` only when the path is
+intentionally shared and visible to the frontend.
 
 If you only wanted timing data and will migrate later, clean up the prepared
 snapshot and state:

--- a/README.md
+++ b/README.md
@@ -75,9 +75,26 @@ oneswap convert <vm> --dry-run
 ```
 
 This reads VM and disk metadata, estimates export, qcow2 conversion, and
-OpenNebula import time, and uses the configured fallback throughput values from
-`oneswap.yaml`. It does not create VMware snapshots, OpenNebula images, or
-OpenNebula templates, and it does not modify the source VM.
+OpenNebula import time. It reports estimate basis, rates, phase durations, and
+confidence. Source export and conversion use configured fallback values unless
+matching regular conversion metrics are available. Target import can reuse
+matching previous OpenNebula import metrics or a benchmark metric for the
+current transfer mode. Without `--benchmark-import`, it does not create VMware
+snapshots, OpenNebula images, or OpenNebula templates, and it does not modify
+the source VM.
+
+To benchmark the OpenNebula image import path before a regular dry-run:
+
+```
+oneswap convert <vm> --dry-run --benchmark-import
+```
+
+With `http_transfer` enabled, this creates a temporary non-sparse raw test
+file, imports it as a temporary OpenNebula image, records the measured import
+rate, deletes the temporary image/file, and then runs the dry-run estimate.
+When `http_transfer` is disabled, local-path benchmarking is skipped; the
+estimate uses matching local-path full import metrics or
+`dry_run_target_import_mib_s`.
 
 ### Delta Dry-run Workflow
 

--- a/esxi_client.rb
+++ b/esxi_client.rb
@@ -80,6 +80,28 @@ class ESXi::Client
         s
     end
 
+    def snapshot_id_by_name(vm_id, name)
+        actions = "snapshot.get #{vm_id}"
+        stdout, _stderr, status = vm_cmd(actions)
+        return nil unless status
+
+        current_id = nil
+        current_name = nil
+        stdout.each_line do |line|
+            current_id = Regexp.last_match(1) if line =~ /Snapshot Id\s*:\s*(\d+)/
+            current_name = Regexp.last_match(1).strip if line =~ /Snapshot Name\s*:\s*(.*)$/
+            return current_id if current_id && current_name == name
+        end
+
+        nil
+    end
+
+    def remove_snapshot_vm(vm_id, snapshot_id)
+        actions = "snapshot.remove #{vm_id} #{snapshot_id} false"
+        _, _, s = vm_cmd(actions)
+        s
+    end
+
     def shutdown_vm(vm_id, vmware_tools = false)
         @logger.info "Shutting down VM #{vm_id}"
 

--- a/esxi_client.rb
+++ b/esxi_client.rb
@@ -198,7 +198,7 @@ class ESXi::Client
             return false
         end
 
-        cmd = "rm -r #{target}"
+        cmd = "rm -r #{Shellwords.escape(target)}"
         message = "Failed to remove files at #{target} on ESXi host #{@host}"
         simple_ssh_execution(cmd, message)
     end
@@ -208,6 +208,20 @@ class ESXi::Client
 
         cmd = "mkdir -p #{dir}"
         message = "Failed to create directory #{dir} on ESXi host #{@host}"
+        simple_ssh_execution(cmd, message)
+    end
+
+    def create_zero_file(path, size_mib)
+        if !path.start_with?(DATASTORES_PATH) || path.include?("'")
+            @logger.error "Refusing to create file outside datastore path: #{path}"
+            return false
+        end
+
+        size_mib = size_mib.to_i
+        return false if size_mib <= 0
+
+        cmd = "dd if=/dev/zero of=#{Shellwords.escape(path)} bs=1M count=#{size_mib}"
+        message = "Failed to create benchmark file #{path} on ESXi host #{@host}"
         simple_ssh_execution(cmd, message)
     end
 

--- a/esxi_client.rb
+++ b/esxi_client.rb
@@ -1,6 +1,8 @@
 require 'open3'
 require 'logger'
 require 'fileutils'
+require 'tempfile'
+require 'shellwords'
 
 module ESXi; end
 
@@ -17,8 +19,14 @@ class ESXi::Client
     def initialize(host, logger = self.class.stdout_logger, options = {})
         @host = host
         @logger = logger
-        @ssh_options = options[:non_interactive] ? '-o BatchMode=yes -o NumberOfPasswordPrompts=0' : ''
-        precheck
+        @user = options[:user] || USER
+        @password = options[:password]
+        @non_interactive = options[:non_interactive] || false
+        @ssh_options = ''
+        @ssh_env = {}
+
+        authenticate!
+        dependency_precheck
 
         @vm_list = []
     end
@@ -157,7 +165,7 @@ class ESXi::Client
     def pull_files(files, target)
         source = "#{@host}:#{files}"
         @logger.info "Copying files from #{source} to #{target}"
-        scp("#{USER}@#{source}", target)
+        scp("#{@user}@#{source}", target)
     end
 
     def remove_files(target)
@@ -314,15 +322,30 @@ class ESXi::Client
         logger
     end
 
-    def precheck
+    def authenticate!
         check_cmd = "#{CTRL_CMD} -v"
+        @ssh_options = '-o BatchMode=yes -o NumberOfPasswordPrompts=0'
+        @ssh_env = {}
         _, _, s = ssh(check_cmd)
+        return true if s
 
-        if !s
-            @logger.error "Failed to run #{check_cmd} as user #{USER} via SSH on ESXi host #{@host}"
-            raise "#{USER} passwordless SSH access is required for the ESXi Client"
+        if @password && !@password.to_s.empty?
+            configure_password_auth
+            _, _, s = ssh(check_cmd)
+            return true if s
         end
 
+        if !@non_interactive
+            @ssh_options = '-o NumberOfPasswordPrompts=3'
+            @ssh_env = {}
+            _, _, s = ssh(check_cmd)
+            return true if s
+        end
+
+        raise "Unable to authenticate to ESXi host #{@user}@#{@host}. Configure passwordless SSH or set esxi_user/esxi_pass. Authentication failed after 3 attempts."
+    end
+
+    def dependency_precheck
         CLI_UTILS.each do |cmd|
             if !ESXi::Client.command_exists?(cmd)
                 message = "Command #{cmd} not found. Limited functionality available"
@@ -340,14 +363,14 @@ class ESXi::Client
     end
 
     def ssh(cmd)
-        ssh_cmd = "ssh #{@ssh_options} #{USER}@#{@host} '#{cmd}'"
-        execute(ssh_cmd)
+        ssh_cmd = "ssh #{@ssh_options} #{@user}@#{@host} '#{cmd}'"
+        execute(ssh_cmd, @ssh_env)
     end
 
     def scp(source, target)
-        cmd = "scp -r #{source} #{target}"
+        cmd = "scp #{@ssh_options} -r #{source} #{target}"
         message = "Failed to perform remote copy from #{source} to #{target}"
-        live_execution(cmd, message)
+        live_execution(cmd, message, @ssh_env)
     end
 
     def simple_execution(cmd, error_message = nil)
@@ -358,9 +381,9 @@ class ESXi::Client
         s
     end
 
-    def live_execution(cmd, error_message = nil)
+    def live_execution(cmd, error_message = nil, env = {})
         status = nil
-        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+        Open3.popen3(env, cmd) do |stdin, stdout, stderr, wait_thr|
             stdin.close
 
             threads = []
@@ -376,11 +399,11 @@ class ESXi::Client
         status
     end
 
-    def execute(cmd)
+    def execute(cmd, env = {})
         @logger.debug "Running command #{cmd}"
 
         t0 = Time.now
-        stdout, stderr, status = Open3.capture3(cmd)
+        stdout, stderr, status = Open3.capture3(env, cmd)
         @logger.debug "Execution time #{Time.now - t0}"
 
         if !status.success?
@@ -393,6 +416,20 @@ class ESXi::Client
 
     def log_host_operation(operation_message)
         @logger.info("#{operation_message} on ESXi host #{@host}")
+    end
+
+    def configure_password_auth
+        @askpass_file = Tempfile.new('oneswap-esxi-askpass')
+        @askpass_file.write("#!/bin/sh\nprintf '%s\\n' #{Shellwords.escape(@password)}\n")
+        @askpass_file.close
+        File.chmod(0o700, @askpass_file.path)
+
+        @ssh_options = '-o BatchMode=no -o NumberOfPasswordPrompts=1'
+        @ssh_env = {
+            'SSH_ASKPASS' => @askpass_file.path,
+            'SSH_ASKPASS_REQUIRE' => 'force',
+            'DISPLAY' => ENV['DISPLAY'].to_s.empty? ? 'none:0' : ENV['DISPLAY']
+        }
     end
 
 end

--- a/esxi_client.rb
+++ b/esxi_client.rb
@@ -96,6 +96,29 @@ class ESXi::Client
         nil
     end
 
+    def snapshots(vm_id)
+        actions = "snapshot.get #{vm_id}"
+        stdout, _stderr, status = vm_cmd(actions)
+        return [] unless status
+
+        snapshots = []
+        current = nil
+        stdout.each_line do |line|
+            if line =~ /Snapshot Id\s*:\s*(\d+)/
+                current = { :id => Regexp.last_match(1) }
+                snapshots << current
+            elsif current && line =~ /Snapshot Name\s*:\s*(.*)$/
+                current[:name] = Regexp.last_match(1).strip
+            elsif current && line =~ /Snapshot Desciption\s*:\s*(.*)$/
+                current[:description] = Regexp.last_match(1).strip
+            elsif current && line =~ /Snapshot Description\s*:\s*(.*)$/
+                current[:description] = Regexp.last_match(1).strip
+            end
+        end
+
+        snapshots
+    end
+
     def remove_snapshot_vm(vm_id, snapshot_id)
         actions = "snapshot.remove #{vm_id} #{snapshot_id} false"
         _, _, s = vm_cmd(actions)

--- a/esxi_client.rb
+++ b/esxi_client.rb
@@ -14,9 +14,10 @@ class ESXi::Client
 
     attr_reader :logger
 
-    def initialize(host, logger = self.class.stdout_logger)
+    def initialize(host, logger = self.class.stdout_logger, options = {})
         @host = host
         @logger = logger
+        @ssh_options = options[:non_interactive] ? '-o BatchMode=yes -o NumberOfPasswordPrompts=0' : ''
         precheck
 
         @vm_list = []
@@ -214,6 +215,21 @@ class ESXi::Client
         live_execution(cmd, message)
     end
 
+    def file_size_bytes(path)
+        if !path.start_with?(DATASTORES_PATH) || path.include?("'")
+            @logger.error "Refusing to read file size outside datastore path: #{path}"
+            return nil
+        end
+
+        stdout, _stderr, status = ssh("ls -ln \"#{path}\"")
+        return nil unless status
+
+        size = stdout.lines.last.to_s.split[4]
+        return nil unless size && size =~ /^\d+$/
+
+        size.to_i
+    end
+
     private
 
     def self.vmsvc_getallvms_to_array(getallvms_output)
@@ -324,7 +340,7 @@ class ESXi::Client
     end
 
     def ssh(cmd)
-        ssh_cmd = "ssh #{USER}@#{@host} '#{cmd}'"
+        ssh_cmd = "ssh #{@ssh_options} #{USER}@#{@host} '#{cmd}'"
         execute(ssh_cmd)
     end
 

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -52,22 +52,28 @@ class ESXi::VirtualMachine
 
     # TODO: Report document output with timers
     def live2kvm(target_dir)
+        return false unless live2kvm_prepare(target_dir)
+
+        live2kvm_commit(target_dir)
+    end
+
+    def live2kvm_prepare(target_dir)
         return false unless live_storage_transfer_precheck
 
-        transfer_dir = "#{target_dir}/esxi_client-#{@name}"
+        transfer_dir = live2kvm_transfer_dir(target_dir)
         live_storage_transfer_cleanup(transfer_dir)
 
-        results_dir = "#{target_dir}/esxi2kvm-#{@name}"
+        results_dir = live2kvm_results_dir(target_dir)
         FileUtils.rm_r(results_dir) if Dir.exist?(results_dir)
 
         @logger.info "Creating premigrate snapshot for VM #{@name}"
-        if !(if vmwaretools?
-                 create_snapshot
-             else
-                 name = ESXi::Client.default_snapshot_name
-                 options = ESXi::Client.default_snapshot_options.merge({ :quiesce => true })
-                 create_snapshot(name, options)
-             end)
+        snapshot_name = ESXi::Client.default_snapshot_name
+        snapshot_options = ESXi::Client.default_snapshot_options
+        if !vmwaretools?
+            snapshot_options = snapshot_options.merge({ :quiesce => true })
+        end
+
+        if !create_snapshot(snapshot_name, snapshot_options)
 
             @logger.error 'Aborting live storage transfer due to failed snapshot creation'
             return false
@@ -81,14 +87,25 @@ class ESXi::VirtualMachine
         end
 
         refresh_vmx # snapshots created new active disks
+        disks = []
         active_disks.each do |disk|
             vmdk_data = vmdk_info(disk)
             parent_disk = vmdk_data['parentFileNameHint']
+            disk_name = disk.chomp('.vmdk')
+            parent_disk_name = parent_disk.chomp('.vmdk')
 
             clone_source = storage_path(parent_disk)
             clone_target = "#{@clone_dir}/#{parent_disk}"
 
-            next if @client.clone_virtual_disk(clone_source, clone_target)
+            if @client.clone_virtual_disk(clone_source, clone_target)
+                disks << {
+                    'active_snapshot_descriptor' => disk,
+                    'active_snapshot_extent' => "#{disk_name}-sesparse.vmdk",
+                    'parent_base_descriptor' => parent_disk,
+                    'converted_raw_base_path' => "#{transfer_dir}/convert/#{parent_disk_name}.raw"
+                }
+                next
+            end
 
             message = "failed disk #{parent_disk} clone"
 
@@ -98,7 +115,7 @@ class ESXi::VirtualMachine
 
         @logger.info "Transferring VM #{@name} storage to #{transfer_dir}"
         if !@client.pull_files("#{@clone_dir}/*", transfer_dir)
-            message = "failed disk #{parent_disk} transfer"
+            message = 'failed disk transfer'
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
@@ -122,6 +139,36 @@ class ESXi::VirtualMachine
             return false
         end
 
+        state = {
+            'vm_name' => @name,
+            'vm_storage_path' => @vm_storage,
+            'datastore_path' => "#{ESXi::Client::DATASTORES_PATH}/#{@datastore}",
+            'snapshot_name' => snapshot_name,
+            'transfer_dir' => transfer_dir,
+            'convert_dir' => convert_dir,
+            'results_dir' => results_dir,
+            # Delta size is only a point-in-time value while the VM keeps running;
+            # it can continue growing until the final commit phase shuts it down.
+            'delta_size_bytes' => nil,
+            'disks' => disks
+        }
+        if !write_live2kvm_state(target_dir, state)
+            message = 'failed to persist delta migration state'
+            live_storage_transfer_cleanup(transfer_dir, message)
+            return false
+        end
+
+        state
+    end
+
+    def live2kvm_commit(target_dir)
+        state = read_live2kvm_state(target_dir)
+        return false unless state
+
+        transfer_dir = state['transfer_dir']
+        convert_dir = state['convert_dir']
+        results_dir = state['results_dir']
+
         t0 = Time.now
         @logger.warn "Shutting down VM #{@name}. Downtime begins"
         if !shutdown
@@ -131,20 +178,17 @@ class ESXi::VirtualMachine
         end
 
         # transfer and apply active snapshot vmdk
-        active_disks.each do |disk|
+        state['disks'].each do |disk_data|
             # alma9-clone_17-000022.vmdk
             # alma9-clone --> vm name
             # _17 --> disk identifier
             # --> 000022 snapshots
-            disk_name = disk.chomp('.vmdk')
-
-            vmdk_data = vmdk_info(disk)
-            parent_disk = vmdk_data['parentFileNameHint']
-            parent_disk_name = parent_disk.chomp('.vmdk')
+            disk = disk_data['active_snapshot_descriptor']
+            snapshot_extent = disk_data['active_snapshot_extent']
 
             # copy vmdk metadata + bits
-            ['', '-sesparse'].each do |suffix|
-                source = storage_path("#{disk_name}#{suffix}.vmdk")
+            [disk, snapshot_extent].each do |file|
+                source = storage_path(file)
 
                 next if @client.pull_files(source, transfer_dir)
 
@@ -154,8 +198,8 @@ class ESXi::VirtualMachine
             end
 
             # apply active snapshot to flat converted disk
-            snapshot = "#{transfer_dir}/#{disk_name}-sesparse.vmdk"
-            parent = "#{convert_dir}/#{parent_disk_name}.raw"
+            snapshot = "#{transfer_dir}/#{snapshot_extent}"
+            parent = disk_data['converted_raw_base_path']
 
             next if @client.apply_vmdk_snapshot_to_raw(snapshot, parent)
 
@@ -192,6 +236,32 @@ class ESXi::VirtualMachine
         live_storage_transfer_cleanup(transfer_dir)
 
         results_dir
+    end
+
+    def live2kvm_current_delta_size_bytes(target_dir)
+        state = read_live2kvm_state(target_dir)
+        return nil unless state
+
+        disks = state['disks']
+        return nil unless disks.is_a?(Array) && !disks.empty?
+
+        total = 0
+        disks.each do |disk_data|
+            extent = disk_data['active_snapshot_extent']
+            return nil if extent.to_s.empty?
+
+            # This is a point-in-time value. While the VM keeps running after
+            # prepare, snapshot delta extents can continue to grow.
+            size = @client.file_size_bytes(storage_path(extent))
+            return nil if size.nil?
+
+            total += size
+        end
+
+        state['delta_size_bytes'] = total
+        write_live2kvm_state(target_dir, state)
+
+        total
     end
 
     def disable_autostart
@@ -260,6 +330,39 @@ class ESXi::VirtualMachine
     end
 
     private
+
+    def live2kvm_transfer_dir(target_dir)
+        "#{target_dir}/esxi_client-#{@name}"
+    end
+
+    def live2kvm_results_dir(target_dir)
+        "#{target_dir}/esxi2kvm-#{@name}"
+    end
+
+    def live2kvm_state_file(target_dir)
+        "#{live2kvm_transfer_dir(target_dir)}/oneswap-delta-state.yaml"
+    end
+
+    def write_live2kvm_state(target_dir, state)
+        File.write(live2kvm_state_file(target_dir), state.to_yaml)
+        true
+    rescue StandardError => e
+        @logger.error "Failed to write delta migration state: #{e.message}"
+        false
+    end
+
+    def read_live2kvm_state(target_dir)
+        state_file = live2kvm_state_file(target_dir)
+        if !File.exist?(state_file)
+            @logger.error "Delta migration state file not found at #{state_file}"
+            return nil
+        end
+
+        YAML.load_file(state_file)
+    rescue StandardError => e
+        @logger.error "Failed to read delta migration state: #{e.message}"
+        nil
+    end
 
     def live_storage_transfer_precheck
         if !running?

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -210,6 +210,7 @@ class ESXi::VirtualMachine
         transfer_dir = state['transfer_dir']
         convert_dir = state['convert_dir']
         results_dir = state['results_dir']
+        @clone_dir = state['clone_dir'] || @clone_dir
 
         t0 = Time.now
         @logger.warn "Shutting down VM #{@name}. Downtime begins"
@@ -287,6 +288,14 @@ class ESXi::VirtualMachine
         @logger.info "Migrated VM #{@name} to KVM with downtime #{t_downtime_formatted}. VM disks at #{results_dir}"
         @logger.info "VM disks at #{results_dir}"
 
+        state_file = live2kvm_state_file(target_dir)
+        snapshot_removed = cleanup_snapshot(state)
+        vmx_verified = verify_vmx_base_disks(state, state_file)
+        if !snapshot_removed || !vmx_verified
+            snapshot_name = state['snapshot_name']
+            puts "Warning: failed to fully clean up VMware snapshot #{snapshot_name}; prepared state was #{state_file}."
+        end
+
         live_storage_transfer_cleanup(transfer_dir)
 
         results_dir
@@ -356,7 +365,7 @@ class ESXi::VirtualMachine
         state = read_live2kvm_state(target_dir)
         if state.nil?
             puts "No prepared delta state found at #{live2kvm_state_file(target_dir)}."
-            return false
+            return cleanup_leftover_oneswap_snapshots(live2kvm_state_file(target_dir))
         end
 
         cleanup_snapshot(state)
@@ -502,21 +511,88 @@ class ESXi::VirtualMachine
         snapshot_name = state['snapshot_name']
         if snapshot_name.to_s.empty?
             puts 'Snapshot name is missing from prepared state; automatic snapshot cleanup is unavailable.'
-            return
+            return false
         end
 
         puts "Removing VMware snapshot #{snapshot_name}..."
         snapshot_id = @client.snapshot_id_by_name(@id, snapshot_name)
         if snapshot_id.nil?
             puts "Warning: VMware snapshot #{snapshot_name} was not found; continuing cleanup."
-            return
+            return true
         end
 
         if @client.remove_snapshot_vm(@id, snapshot_id)
             puts "Removed VMware snapshot #{snapshot_name}."
+            return true
         else
             puts "Warning: failed to remove VMware snapshot #{snapshot_name}; continuing cleanup."
+            return false
         end
+    end
+
+    def cleanup_leftover_oneswap_snapshots(state_file)
+        snapshots = @client.snapshots(@id).select {|snapshot| oneswap_snapshot?(snapshot) }
+        if snapshots.empty?
+            puts "Warning: no snapshots with a OneSwap marker were found for VM #{@name}; not removing any snapshots without prepared state."
+            return true
+        end
+
+        all_removed = true
+        snapshots.each do |snapshot|
+            snapshot_info = "#{snapshot[:name]} (id #{snapshot[:id]}, description: #{snapshot[:description]})"
+            puts "Removing leftover OneSwap snapshot #{snapshot_info}..."
+            if @client.remove_snapshot_vm(@id, snapshot[:id])
+                puts "Removed leftover OneSwap snapshot #{snapshot_info}."
+            else
+                all_removed = false
+                puts "Warning: failed to remove leftover OneSwap snapshot for VM #{@name}: #{snapshot_info}."
+            end
+        end
+
+        vmx_verified = verify_vmx_base_disks({}, state_file)
+        if all_removed && vmx_verified
+            puts 'Leftover OneSwap snapshot cleanup completed.'
+            return true
+        end
+
+        puts "Warning: leftover OneSwap snapshot cleanup for VM #{@name} did not fully complete."
+        false
+    end
+
+    def oneswap_snapshot?(snapshot)
+        snapshot[:description].to_s == ESXi::Client.default_snapshot_options[:description] ||
+            snapshot[:name].to_s.start_with?('OneSwap ')
+    end
+
+    def verify_vmx_base_disks(state, state_file)
+        snapshot_disks = state['disks'].to_a.map {|disk| disk['active_snapshot_descriptor'] }.compact
+        still_active = []
+
+        12.times do |attempt|
+            refresh_vmx
+            active_disks = self.class.active_vmdks(@vmx)
+            still_active = active_disks & snapshot_disks
+            still_active += active_disks.select {|disk| snapshot_descriptor?(disk) }
+            still_active.uniq!
+            if still_active.empty?
+                puts 'Verified VMX disk backing no longer points to the OneSwap snapshot descriptor.'
+                return true
+            end
+
+            sleep 5 if attempt < 11
+        end
+
+        puts "Warning: VMX still points to snapshot descriptor(s): #{still_active.join(', ')}."
+        puts "Warning: prepared state was #{state_file}."
+        false
+    rescue StandardError => e
+        puts "Warning: unable to verify VMX disk backing after snapshot cleanup: #{e.message}."
+        puts "Warning: prepared state was #{state_file}."
+        false
+    end
+
+    def snapshot_descriptor?(disk)
+        disk.to_s =~ /-\d{6}\.vmdk$/
     end
 
     def cleanup_clone_dir(state)

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -180,6 +180,7 @@ class ESXi::VirtualMachine
             'transfer_dir' => transfer_dir,
             'convert_dir' => convert_dir,
             'results_dir' => results_dir,
+            'clone_dir' => @clone_dir,
             # Delta size is only a point-in-time value while the VM keeps running;
             # it can continue growing until the final commit phase shuts it down.
             'delta_size_bytes' => nil,
@@ -249,10 +250,18 @@ class ESXi::VirtualMachine
         end
 
         converted_disks = Dir.children(convert_dir)
+        os_morph_seconds = 0.0
+        os_morph_disks_tried = 0
         converted_disks.each do |disk|
             root_disk_path = "#{convert_dir}/#{disk}"
 
-            break if @client.os_morph(root_disk_path, VIRT_V2V_OPTIONS_EXTRA)
+            t_os_morph = Time.now
+            os_morph_disks_tried += 1
+            if @client.os_morph(root_disk_path, VIRT_V2V_OPTIONS_EXTRA)
+                os_morph_seconds += Time.now - t_os_morph
+                break
+            end
+            os_morph_seconds += Time.now - t_os_morph
 
             if converted_disks.last != disk
                 @logger.warn "Failed to morph OS on disk #{disk}"
@@ -266,6 +275,10 @@ class ESXi::VirtualMachine
         end
 
         FileUtils.mv(convert_dir, results_dir)
+        write_live2kvm_metrics(target_dir, {
+                                   'delta_os_morph_seconds' => os_morph_seconds,
+                                   'delta_os_morph_disks_tried' => os_morph_disks_tried
+                               })
 
         t_downtime = Time.now - t0
         t_downtime_formatted = Time.at(t_downtime).utc.strftime("%M:%S")
@@ -306,6 +319,22 @@ class ESXi::VirtualMachine
 
     def live2kvm_state(target_dir)
         read_live2kvm_state(target_dir)
+    end
+
+    def live2kvm_cleanup(target_dir)
+        puts "Cleaning prepared delta migration for VM #{@name}"
+        state = read_live2kvm_state(target_dir)
+        if state.nil?
+            puts "No prepared delta state found at #{live2kvm_state_file(target_dir)}."
+            return false
+        end
+
+        cleanup_snapshot(state)
+        cleanup_clone_dir(state)
+        cleanup_local_state(target_dir, state)
+
+        puts 'Delta prepare cleanup completed.'
+        true
     end
 
     def disable_autostart
@@ -387,6 +416,10 @@ class ESXi::VirtualMachine
         "#{live2kvm_transfer_dir(target_dir)}/oneswap-delta-state.yaml"
     end
 
+    def live2kvm_metrics_file(target_dir)
+        "#{target_dir}/oneswap-metrics.yaml"
+    end
+
     def write_live2kvm_state(target_dir, state)
         File.write(live2kvm_state_file(target_dir), state.to_yaml)
         true
@@ -408,6 +441,17 @@ class ESXi::VirtualMachine
         nil
     end
 
+    def write_live2kvm_metrics(target_dir, metrics)
+        current = if File.exist?(live2kvm_metrics_file(target_dir))
+                      YAML.load_file(live2kvm_metrics_file(target_dir)) || {}
+                  else
+                      {}
+                  end
+        File.write(live2kvm_metrics_file(target_dir), current.merge(metrics).to_yaml)
+    rescue StandardError => e
+        @logger.warn "Failed to write delta migration metrics: #{e.message}"
+    end
+
     def format_elapsed(seconds)
         "#{seconds.round(2)}s"
     end
@@ -422,6 +466,59 @@ class ESXi::VirtualMachine
         return nil if bytes.to_i <= 0 || seconds.to_f <= 0
 
         (bytes.to_f / (1024 * 1024)) / seconds.to_f
+    end
+
+    def cleanup_snapshot(state)
+        snapshot_name = state['snapshot_name']
+        if snapshot_name.to_s.empty?
+            puts 'Snapshot name is missing from prepared state; automatic snapshot cleanup is unavailable.'
+            return
+        end
+
+        puts "Removing VMware snapshot #{snapshot_name}..."
+        snapshot_id = @client.snapshot_id_by_name(@id, snapshot_name)
+        if snapshot_id.nil?
+            puts "Warning: VMware snapshot #{snapshot_name} was not found; continuing cleanup."
+            return
+        end
+
+        if @client.remove_snapshot_vm(@id, snapshot_id)
+            puts "Removed VMware snapshot #{snapshot_name}."
+        else
+            puts "Warning: failed to remove VMware snapshot #{snapshot_name}; continuing cleanup."
+        end
+    end
+
+    def cleanup_clone_dir(state)
+        clone_dir = state['clone_dir'] || @clone_dir
+        if clone_dir.to_s.empty? || !clone_dir.start_with?(ESXi::Client::DATASTORES_PATH)
+            puts 'Warning: ESXi clone directory is missing or unsafe; skipping remote clone cleanup.'
+            return
+        end
+
+        puts "Removing ESXi clone directory #{clone_dir}..."
+        if @client.remove_files(clone_dir)
+            puts "Removed ESXi clone directory #{clone_dir}."
+        else
+            puts "Warning: failed to remove ESXi clone directory #{clone_dir}; continuing cleanup."
+        end
+    end
+
+    def cleanup_local_state(target_dir, state)
+        transfer_dir = state['transfer_dir']
+        expected_dir = live2kvm_transfer_dir(target_dir)
+        if transfer_dir != expected_dir
+            puts "Warning: prepared state path #{transfer_dir} does not match expected #{expected_dir}; skipping local cleanup."
+            return
+        end
+
+        puts "Removing local prepared state #{transfer_dir}..."
+        if Dir.exist?(transfer_dir)
+            FileUtils.remove_dir(transfer_dir)
+            puts "Removed local prepared state #{transfer_dir}."
+        else
+            puts "Warning: local prepared state #{transfer_dir} is already gone."
+        end
     end
 
     def live_storage_transfer_precheck

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -136,13 +136,18 @@ class ESXi::VirtualMachine
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
-        puts "Transferred base disk files in #{format_elapsed(Time.now - t0)}."
+        base_transfer_seconds = Time.now - t0
+        base_transfer_bytes = local_tree_size(transfer_dir)
+        base_transfer_mib_s = mib_per_second(base_transfer_bytes, base_transfer_seconds)
+        puts "Transferred base disk files in #{format_elapsed(base_transfer_seconds)}."
 
         cloned_vmdk_list = Dir.children(transfer_dir)
 
         convert_dir = "#{transfer_dir}/convert"
         Dir.mkdir(convert_dir) unless Dir.exist?(convert_dir)
 
+        base_convert_seconds = 0.0
+        base_convert_bytes = 0
         cloned_vmdk_list.each do |file|
             next if file.end_with?('-flat.vmdk')
 
@@ -153,7 +158,10 @@ class ESXi::VirtualMachine
             puts "Converting base disk to raw: #{file}..."
             t0 = Time.now
             if @client.convert_vmdk(source, target, format)
-                puts "Converted #{file} to raw in #{format_elapsed(Time.now - t0)}."
+                elapsed = Time.now - t0
+                base_convert_seconds += elapsed
+                base_convert_bytes += File.size(target) if File.exist?(target)
+                puts "Converted #{file} to raw in #{format_elapsed(elapsed)}."
                 next
             end
 
@@ -161,6 +169,7 @@ class ESXi::VirtualMachine
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
+        base_convert_mib_s = mib_per_second(base_convert_bytes, base_convert_seconds)
 
         puts 'Writing prepared delta state...'
         state = {
@@ -174,6 +183,12 @@ class ESXi::VirtualMachine
             # Delta size is only a point-in-time value while the VM keeps running;
             # it can continue growing until the final commit phase shuts it down.
             'delta_size_bytes' => nil,
+            'base_transfer_bytes' => base_transfer_bytes,
+            'base_transfer_seconds' => base_transfer_seconds,
+            'base_transfer_mib_s' => base_transfer_mib_s,
+            'base_convert_bytes' => base_convert_bytes,
+            'base_convert_seconds' => base_convert_seconds,
+            'base_convert_mib_s' => base_convert_mib_s,
             'disks' => disks
         }
         if !write_live2kvm_state(target_dir, state)
@@ -289,6 +304,10 @@ class ESXi::VirtualMachine
         total
     end
 
+    def live2kvm_state(target_dir)
+        read_live2kvm_state(target_dir)
+    end
+
     def disable_autostart
         @client.disable_vm_autostart(@id)
     end
@@ -391,6 +410,18 @@ class ESXi::VirtualMachine
 
     def format_elapsed(seconds)
         "#{seconds.round(2)}s"
+    end
+
+    def local_tree_size(path)
+        Dir.glob("#{path}/**/*", File::FNM_DOTMATCH).sum do |file|
+            File.file?(file) ? File.size(file) : 0
+        end
+    end
+
+    def mib_per_second(bytes, seconds)
+        return nil if bytes.to_i <= 0 || seconds.to_f <= 0
+
+        (bytes.to_f / (1024 * 1024)) / seconds.to_f
     end
 
     def live_storage_transfer_precheck

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -58,15 +58,22 @@ class ESXi::VirtualMachine
     end
 
     def live2kvm_prepare(target_dir)
+        puts "Starting delta prepare for VM #{@name}."
+        puts 'Running delta prepare prechecks...'
         return false unless live_storage_transfer_precheck
+        puts 'Delta prepare prechecks completed.'
 
         transfer_dir = live2kvm_transfer_dir(target_dir)
+        puts "Cleaning previous delta work directories at #{transfer_dir}..."
         live_storage_transfer_cleanup(transfer_dir)
 
         results_dir = live2kvm_results_dir(target_dir)
         FileUtils.rm_r(results_dir) if Dir.exist?(results_dir)
+        puts 'Previous delta work directories cleaned.'
 
+        puts "Creating premigrate snapshot for VM #{@name}..."
         @logger.info "Creating premigrate snapshot for VM #{@name}"
+        t0 = Time.now
         snapshot_name = ESXi::Client.default_snapshot_name
         snapshot_options = ESXi::Client.default_snapshot_options
         if !vmwaretools?
@@ -78,6 +85,7 @@ class ESXi::VirtualMachine
             @logger.error 'Aborting live storage transfer due to failed snapshot creation'
             return false
         end
+        puts "Snapshot created in #{format_elapsed(Time.now - t0)}."
 
         FileUtils.mkdir_p(transfer_dir) unless Dir.exist?(transfer_dir)
         if !@client.create_dir(@clone_dir)
@@ -86,9 +94,13 @@ class ESXi::VirtualMachine
             return false
         end
 
+        puts 'Reading VMX and detecting active disks...'
+        t0 = Time.now
         refresh_vmx # snapshots created new active disks
+        detected_disks = active_disks
+        puts "Detected #{detected_disks.length} active disk(s) in #{format_elapsed(Time.now - t0)}."
         disks = []
-        active_disks.each do |disk|
+        detected_disks.each do |disk|
             vmdk_data = vmdk_info(disk)
             parent_disk = vmdk_data['parentFileNameHint']
             disk_name = disk.chomp('.vmdk')
@@ -97,7 +109,10 @@ class ESXi::VirtualMachine
             clone_source = storage_path(parent_disk)
             clone_target = "#{@clone_dir}/#{parent_disk}"
 
+            puts "Cloning base disk on ESXi: #{parent_disk}..."
+            t0 = Time.now
             if @client.clone_virtual_disk(clone_source, clone_target)
+                puts "Cloned base disk #{parent_disk} in #{format_elapsed(Time.now - t0)}."
                 disks << {
                     'active_snapshot_descriptor' => disk,
                     'active_snapshot_extent' => "#{disk_name}-sesparse.vmdk",
@@ -114,11 +129,14 @@ class ESXi::VirtualMachine
         end
 
         @logger.info "Transferring VM #{@name} storage to #{transfer_dir}"
+        puts "Transferring base disk files to local work dir #{transfer_dir}..."
+        t0 = Time.now
         if !@client.pull_files("#{@clone_dir}/*", transfer_dir)
             message = 'failed disk transfer'
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
+        puts "Transferred base disk files in #{format_elapsed(Time.now - t0)}."
 
         cloned_vmdk_list = Dir.children(transfer_dir)
 
@@ -132,13 +150,19 @@ class ESXi::VirtualMachine
             target = "#{convert_dir}/#{file.chomp('.vmdk')}.raw"
             format = 'raw'
 
-            next if @client.convert_vmdk(source, target, format)
+            puts "Converting base disk to raw: #{file}..."
+            t0 = Time.now
+            if @client.convert_vmdk(source, target, format)
+                puts "Converted #{file} to raw in #{format_elapsed(Time.now - t0)}."
+                next
+            end
 
             message = "failed disk #{source} conversion"
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
 
+        puts 'Writing prepared delta state...'
         state = {
             'vm_name' => @name,
             'vm_storage_path' => @vm_storage,
@@ -157,6 +181,7 @@ class ESXi::VirtualMachine
             live_storage_transfer_cleanup(transfer_dir, message)
             return false
         end
+        puts "Prepared delta state written to #{live2kvm_state_file(target_dir)}."
 
         state
     end
@@ -362,6 +387,10 @@ class ESXi::VirtualMachine
     rescue StandardError => e
         @logger.error "Failed to read delta migration state: #{e.message}"
         nil
+    end
+
+    def format_elapsed(seconds)
+        "#{seconds.round(2)}s"
     end
 
     def live_storage_transfer_precheck

--- a/esxi_vm.rb
+++ b/esxi_vm.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'time'
 require 'yaml'
 require_relative 'esxi_client'
 
@@ -292,29 +293,58 @@ class ESXi::VirtualMachine
     end
 
     def live2kvm_current_delta_size_bytes(target_dir)
+        info = live2kvm_current_delta_size(target_dir)
+        info && info[:bytes]
+    end
+
+    def live2kvm_current_delta_size(target_dir)
         state = read_live2kvm_state(target_dir)
         return nil unless state
 
         disks = state['disks']
         return nil unless disks.is_a?(Array) && !disks.empty?
+        vm_storage_path = state['vm_storage_path']
+        return nil if vm_storage_path.to_s.empty?
 
         total = 0
+        paths = []
         disks.each do |disk_data|
             extent = disk_data['active_snapshot_extent']
-            return nil if extent.to_s.empty?
+            raise 'prepared state is missing active snapshot extent' if extent.to_s.empty?
 
             # This is a point-in-time value. While the VM keeps running after
             # prepare, snapshot delta extents can continue to grow.
-            size = @client.file_size_bytes(storage_path(extent))
-            return nil if size.nil?
+            path = "#{vm_storage_path}/#{extent}"
+            @logger.debug "Reading live snapshot delta size from #{path}"
+            size = @client.file_size_bytes(path)
+            raise "unable to read live snapshot extent size for #{path}" if size.nil?
 
+            paths << path
             total += size
         end
 
-        state['delta_size_bytes'] = total
+        state['current_delta_size_bytes'] = total
+        state['current_delta_size_refreshed_at'] = Time.now.utc.iso8601
         write_live2kvm_state(target_dir, state)
 
-        total
+        {
+            :bytes => total,
+            :source => 'refreshed from ESXi snapshot extent',
+            :paths => paths,
+            :refreshed => true
+        }
+    rescue StandardError => e
+        @logger.warn "Unable to refresh live snapshot delta size: #{e.message}"
+        stored = state && state['delta_size_bytes'].to_i
+        return nil unless stored && stored > 0
+
+        {
+            :bytes => stored,
+            :source => 'stored prepare-time delta size',
+            :paths => [],
+            :refreshed => false,
+            :warning => 'Warning: unable to refresh live snapshot delta size from ESXi; using stored prepare-time value.'
+        }
     end
 
     def live2kvm_state(target_dir)

--- a/oneswap
+++ b/oneswap
@@ -418,6 +418,12 @@ CommandParser::CmdParser.new(ARGV) do
         :description => 'Benchmark OpenNebula image import during --dry-run using a temporary image.'
     }
 
+    BENCHMARK_EXPORT = {
+        :name => 'benchmark_export',
+        :large => '--benchmark-export',
+        :description => 'Benchmark source export during regular --dry-run using a temporary datastore file.'
+    }
+
     CUSTOM = { # not sure what to call this actually
         :name => 'custom_convert',
         :large => '--custom',
@@ -633,7 +639,7 @@ CommandParser::CmdParser.new(ARGV) do
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT, ALLOW_LOCAL_PATH_REMOTE]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DELTA_CLEANUP, DRY_RUN, BENCHMARK_IMPORT, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DELTA_CLEANUP, DRY_RUN, BENCHMARK_IMPORT, BENCHMARK_EXPORT, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
@@ -742,6 +748,12 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:benchmark_import] && !options[:dry_run]
                 raise '--benchmark-import requires --dry-run.'
             end
+            if options[:benchmark_export] && !options[:dry_run]
+                raise '--benchmark-export requires --dry-run.'
+            end
+            if options[:benchmark_export] && options[:delta]
+                raise '--benchmark-export is only supported for regular non-delta dry-run.'
+            end
 
             if options[:delta]
                 incompatible_delta = []
@@ -798,6 +810,7 @@ CommandParser::CmdParser.new(ARGV) do
             options[:dry_run_delta_os_morph_seconds] ||= 480
             options[:dry_run_guest_customization_seconds] ||= 180
             options[:dry_run_import_benchmark_size_mib] ||= 4096
+            options[:dry_run_source_benchmark_size_mib] ||= 1024
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|

--- a/oneswap
+++ b/oneswap
@@ -415,7 +415,7 @@ CommandParser::CmdParser.new(ARGV) do
     BENCHMARK_IMPORT = {
         :name => 'benchmark_import',
         :large => '--benchmark-import',
-        :description => 'Benchmark OpenNebula image import during --dry-run --delta using a temporary image.'
+        :description => 'Benchmark OpenNebula image import during --dry-run using a temporary image.'
     }
 
     CUSTOM = { # not sure what to call this actually
@@ -739,8 +739,8 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:dry_run] && (options[:delta_prepare] || options[:delta_commit] || options[:delta_cleanup])
                 raise '--dry-run cannot be combined with --delta-prepare, --delta-commit, or --delta-cleanup.'
             end
-            if options[:benchmark_import] && !(options[:dry_run] && options[:delta])
-                raise '--benchmark-import requires --dry-run --delta.'
+            if options[:benchmark_import] && !options[:dry_run]
+                raise '--benchmark-import requires --dry-run.'
             end
 
             if options[:delta]

--- a/oneswap
+++ b/oneswap
@@ -525,6 +525,12 @@ CommandParser::CmdParser.new(ARGV) do
         :format => Integer
     }
 
+    ALLOW_LOCAL_PATH_REMOTE = {
+        :name => 'allow_local_path_remote',
+        :large => '--allow-local-path-remote',
+        :description => 'Allow local PATH image allocation when OpenNebula endpoint appears remote. Use only when work_dir is shared at the same path.'
+    }
+
     CONF_FILE = {
         :name => 'config_file',
         :large => '--config-file /path/to/custom/config.yaml',
@@ -624,7 +630,7 @@ CommandParser::CmdParser.new(ARGV) do
 
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
-    HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
+    HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT, ALLOW_LOCAL_PATH_REMOTE]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DELTA_CLEANUP, DRY_RUN, BENCHMARK_IMPORT, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
@@ -803,7 +809,7 @@ CommandParser::CmdParser.new(ARGV) do
 
                 options[:http_port] ||= 29869
             else
-                if options[:endpoint]
+                if options[:endpoint] && !options[:allow_local_path_remote]
                     raise 'Using alternative OpenNebula endpoint requires HTTP Transfer'
                 end
             end

--- a/oneswap
+++ b/oneswap
@@ -694,6 +694,19 @@ CommandParser::CmdParser.new(ARGV) do
                 raise '--download-stripes N > 1 requires --hybrid.'
             end
 
+            if options[:delta]
+                incompatible_delta = []
+                incompatible_delta << '--custom' if options[:custom_convert]
+                incompatible_delta << '--hybrid' if options[:hybrid]
+                incompatible_delta << '--fallback' if options[:fallback]
+                incompatible_delta << '--vddk' if options[:vddk_path]
+                incompatible_delta << '--esxi' if options[:esxi_ip]
+
+                if !incompatible_delta.empty?
+                    raise "--delta cannot be combined with #{incompatible_delta.join(', ')}."
+                end
+            end
+
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
             raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk_path]
             if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])

--- a/oneswap
+++ b/oneswap
@@ -383,6 +383,12 @@ CommandParser::CmdParser.new(ARGV) do
         :description => 'Convert the VM with reduced downtime using snapshots. Requires ESXi host paswordless root SSH access.'
     }
 
+    DRY_RUN = {
+        :name => 'dry_run',
+        :large => '--dry-run',
+        :description => 'Estimate conversion time without creating snapshots, images, or templates.'
+    }
+
     CUSTOM = { # not sure what to call this actually
         :name => 'custom_convert',
         :large => '--custom',
@@ -592,7 +598,7 @@ CommandParser::CmdParser.new(ARGV) do
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DRY_RUN, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
@@ -724,6 +730,9 @@ CommandParser::CmdParser.new(ARGV) do
             options[:context_min_free] ||= 1024
             options[:context_timeout]  ||= 600
             options[:download_stripes] ||= 1
+            options[:dry_run_source_export_mib_s] ||= 80
+            options[:dry_run_qcow2_conversion_mib_s] ||= 120
+            options[:dry_run_target_import_mib_s] ||= 80
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|

--- a/oneswap
+++ b/oneswap
@@ -71,6 +71,11 @@ CommandParser::CmdParser.new(ARGV) do
     version OpenNebulaHelper::ONE_VERSION
 
     helper = OneSwapHelper.new
+    normalize_config = lambda do |cfg|
+        next cfg unless cfg.respond_to?(:transform_keys)
+
+        cfg.transform_keys {|key| key.to_s.sub(/^:/, '').to_sym }
+    end
 
     before_proc do
         helper.set_client(options)
@@ -395,10 +400,22 @@ CommandParser::CmdParser.new(ARGV) do
         :description => 'Run only the delta final phase from prepared state.'
     }
 
+    DELTA_CLEANUP = {
+        :name => 'delta_cleanup',
+        :large => '--delta-cleanup',
+        :description => 'Clean up prepared delta state, snapshot, and temporary files.'
+    }
+
     DRY_RUN = {
         :name => 'dry_run',
         :large => '--dry-run',
         :description => 'Estimate conversion time without creating snapshots, images, or templates.'
+    }
+
+    BENCHMARK_IMPORT = {
+        :name => 'benchmark_import',
+        :large => '--benchmark-import',
+        :description => 'Benchmark OpenNebula image import during --dry-run --delta using a temporary image.'
     }
 
     CUSTOM = { # not sure what to call this actually
@@ -610,7 +627,7 @@ CommandParser::CmdParser.new(ARGV) do
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DRY_RUN, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DELTA_CLEANUP, DRY_RUN, BENCHMARK_IMPORT, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
@@ -647,7 +664,7 @@ CommandParser::CmdParser.new(ARGV) do
                 raise "Unable to find the config file at #{options[:config_file]}"
             end
 
-            cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
+            cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
             options.merge!(cfg_file) if cfg_file
             options[:object] = args[0]
             helper.parse_opts(options)
@@ -699,21 +716,25 @@ CommandParser::CmdParser.new(ARGV) do
                 puts "Unable to find the config file at #{options[:config_file]}"
             end
             options[:config_file] ||= '/etc/one/oneswap.yaml'
-            cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
+            cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
             options.merge!(cfg_file) if cfg_file
 
             if (options[:download_stripes] || 1).to_i > 1 && !options[:hybrid]
                 raise '--download-stripes N > 1 requires --hybrid.'
             end
 
-            if (options[:delta_prepare] || options[:delta_commit]) && !options[:delta]
-                raise '--delta-prepare and --delta-commit require --delta.'
+            if (options[:delta_prepare] || options[:delta_commit] || options[:delta_cleanup]) && !options[:delta]
+                raise '--delta-prepare, --delta-commit, and --delta-cleanup require --delta.'
             end
-            if options[:delta_prepare] && options[:delta_commit]
-                raise '--delta-prepare cannot be combined with --delta-commit.'
+            delta_phase_count = [options[:delta_prepare], options[:delta_commit], options[:delta_cleanup]].count {|v| v }
+            if delta_phase_count > 1
+                raise '--delta-prepare, --delta-commit, and --delta-cleanup cannot be combined.'
             end
-            if options[:dry_run] && (options[:delta_prepare] || options[:delta_commit])
-                raise '--dry-run cannot be combined with --delta-prepare or --delta-commit.'
+            if options[:dry_run] && (options[:delta_prepare] || options[:delta_commit] || options[:delta_cleanup])
+                raise '--dry-run cannot be combined with --delta-prepare, --delta-commit, or --delta-cleanup.'
+            end
+            if options[:benchmark_import] && !(options[:dry_run] && options[:delta])
+                raise '--benchmark-import requires --dry-run --delta.'
             end
 
             if options[:delta]
@@ -768,6 +789,9 @@ CommandParser::CmdParser.new(ARGV) do
             options[:dry_run_source_export_mib_s] ||= 80
             options[:dry_run_qcow2_conversion_mib_s] ||= 120
             options[:dry_run_target_import_mib_s] ||= 80
+            options[:dry_run_delta_os_morph_seconds] ||= 480
+            options[:dry_run_guest_customization_seconds] ||= 180
+            options[:dry_run_import_benchmark_size_mib] ||= 4096
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|
@@ -837,7 +861,7 @@ CommandParser::CmdParser.new(ARGV) do
             end
 
             options[:config_file] ||= '/etc/one/oneswap.yaml'
-            cfg_file = YAML.load_file(options[:config_file]) if File.exist?(options[:config_file])
+            cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
             options.merge!(cfg_file) if cfg_file
 
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?

--- a/oneswap
+++ b/oneswap
@@ -383,6 +383,18 @@ CommandParser::CmdParser.new(ARGV) do
         :description => 'Convert the VM with reduced downtime using snapshots. Requires ESXi host paswordless root SSH access.'
     }
 
+    DELTA_PREPARE = {
+        :name => 'delta_prepare',
+        :large => '--delta-prepare',
+        :description => 'Run only the delta base phase and persist state for a later dry-run or commit.'
+    }
+
+    DELTA_COMMIT = {
+        :name => 'delta_commit',
+        :large => '--delta-commit',
+        :description => 'Run only the delta final phase from prepared state.'
+    }
+
     DRY_RUN = {
         :name => 'dry_run',
         :large => '--dry-run',
@@ -598,7 +610,7 @@ CommandParser::CmdParser.new(ARGV) do
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
-    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DRY_RUN, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
+    CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DRY_RUN, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
@@ -692,6 +704,16 @@ CommandParser::CmdParser.new(ARGV) do
 
             if (options[:download_stripes] || 1).to_i > 1 && !options[:hybrid]
                 raise '--download-stripes N > 1 requires --hybrid.'
+            end
+
+            if (options[:delta_prepare] || options[:delta_commit]) && !options[:delta]
+                raise '--delta-prepare and --delta-commit require --delta.'
+            end
+            if options[:delta_prepare] && options[:delta_commit]
+                raise '--delta-prepare cannot be combined with --delta-commit.'
+            end
+            if options[:dry_run] && (options[:delta_prepare] || options[:delta_commit])
+                raise '--dry-run cannot be combined with --delta-prepare or --delta-commit.'
             end
 
             if options[:delta]

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -33,6 +33,7 @@
 #:dry_run_delta_os_morph_seconds: 480     # Fallback final virt-v2v-in-place / OS morph duration for delta dry-run.
 #:dry_run_guest_customization_seconds: 180  # Fallback guest inspect/customization/qemu-ga/context duration for delta dry-run.
 #:dry_run_import_benchmark_size_mib: 4096 # Temporary non-sparse raw image size for --dry-run --benchmark-import. Small files can be dominated by OpenNebula fixed overhead.
+#:dry_run_source_benchmark_size_mib: 1024 # Temporary VMware datastore file size for --dry-run --benchmark-export.
 
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -2,6 +2,7 @@
 #:http_transfer: false                    # Enable HTTP transfer
 #:http_host: '192.168.0.10'               # Hostname of this server
 #:http_port: 29869                        # HTTP Port to transfer over
+#:allow_local_path_remote: false          # Allow local PATH image allocation with a remote OpenNebula endpoint only when work_dir is shared at the same path.
 
 # vCenter Authentication
 #:vcenter: '172.20.0.123'                 # vCenter hostname or IP

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -27,8 +27,11 @@
 
 # Dry-run Estimator Options
 #:dry_run_source_export_mib_s: 80         # Fallback source/export throughput in MiB/s. Delta dry-run prefers measured prepare transfer throughput when available.
-#:dry_run_qcow2_conversion_mib_s: 120     # Fallback qcow2 conversion throughput in MiB/s for regular dry-run estimates.
-#:dry_run_target_import_mib_s: 80         # Fallback target import throughput in MiB/s, including delta downtime estimates.
+#:dry_run_qcow2_conversion_mib_s: 120     # Fallback qcow2 conversion/delta-apply throughput in MiB/s when measured prepare conversion is unavailable.
+#:dry_run_target_import_mib_s: 80         # Fallback OpenNebula image import throughput in MiB/s. Tune for the frontend/datastore import path, not only network speed.
+#:dry_run_delta_os_morph_seconds: 480     # Fallback final virt-v2v-in-place / OS morph duration for delta dry-run.
+#:dry_run_guest_customization_seconds: 180  # Fallback guest inspect/customization/qemu-ga/context duration for delta dry-run.
+#:dry_run_import_benchmark_size_mib: 4096 # Temporary non-sparse raw image size for --dry-run --delta --benchmark-import. Small files can be dominated by OpenNebula fixed overhead.
 
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -32,7 +32,7 @@
 #:dry_run_target_import_mib_s: 80         # Fallback OpenNebula image import throughput in MiB/s. Tune for the frontend/datastore import path, not only network speed.
 #:dry_run_delta_os_morph_seconds: 480     # Fallback final virt-v2v-in-place / OS morph duration for delta dry-run.
 #:dry_run_guest_customization_seconds: 180  # Fallback guest inspect/customization/qemu-ga/context duration for delta dry-run.
-#:dry_run_import_benchmark_size_mib: 4096 # Temporary non-sparse raw image size for --dry-run --delta --benchmark-import. Small files can be dominated by OpenNebula fixed overhead.
+#:dry_run_import_benchmark_size_mib: 4096 # Temporary non-sparse raw image size for --dry-run --benchmark-import. Small files can be dominated by OpenNebula fixed overhead.
 
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -25,6 +25,11 @@
 #:download_stripes: 1
 #:img_wait:                               # Amount of time to wait in seconds for image to be created in OpenNebula, default: 120
 
+# Dry-run Estimator Options
+#:dry_run_source_export_mib_s: 80         # Fallback source export throughput in MiB/s
+#:dry_run_qcow2_conversion_mib_s: 120     # Fallback qcow2 conversion throughput in MiB/s
+#:dry_run_target_import_mib_s: 80         # Fallback target import throughput in MiB/s
+
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files
 

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -12,8 +12,8 @@
 
 # ESXi Authentication
 #:esxi_ip: '172.20.0.123'                 # ESXi hostname or IP
-#:esxi_user: 'root'                       # ESXi username
-#:esxi_pass: 'changeme123'                # ESXi password
+#:esxi_user: 'root'                       # ESXi username. Also used by delta prepare/commit when passwordless SSH is not available.
+#:esxi_pass: 'changeme123'                # ESXi password. Also used by delta prepare/commit when passwordless SSH is not available.
 
 # Transfer Options
 #:custom_convert:                         # Uses OpenNebula's custom conversion process, useful for distributions which are not supported or fail to convert
@@ -26,9 +26,9 @@
 #:img_wait:                               # Amount of time to wait in seconds for image to be created in OpenNebula, default: 120
 
 # Dry-run Estimator Options
-#:dry_run_source_export_mib_s: 80         # Fallback source export throughput in MiB/s
-#:dry_run_qcow2_conversion_mib_s: 120     # Fallback qcow2 conversion throughput in MiB/s
-#:dry_run_target_import_mib_s: 80         # Fallback target import throughput in MiB/s
+#:dry_run_source_export_mib_s: 80         # Fallback source/export throughput in MiB/s. Delta dry-run prefers measured prepare transfer throughput when available.
+#:dry_run_qcow2_conversion_mib_s: 120     # Fallback qcow2 conversion throughput in MiB/s for regular dry-run estimates.
+#:dry_run_target_import_mib_s: 80         # Fallback target import throughput in MiB/s, including delta downtime estimates.
 
 # Import Options
 #:ova: /path/to/ova                       # Path to OVA or folder with OVF files

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -19,9 +19,11 @@ require 'opennebula'
 require 'logger'
 require 'fileutils'
 require 'shellwords'
+require 'socket'
 require 'tempfile'
 require 'tmpdir'
 require 'time'
+require 'uri'
 require 'webrick'
 require 'yaml'
 require_relative 'vsphere_client'
@@ -1809,6 +1811,8 @@ _EOF_"
 
     # Passworldess root access to ESXi host IP required
     def run_delta_conversion
+        local_path_image_allocation_preflight!
+
         client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options)
 
         vm_name = @options[:name]
@@ -1825,6 +1829,55 @@ _EOF_"
         disks_on_file = Dir.children(conversion_dir).map {|disk| File.join(conversion_dir, disk) }
 
         create_one_images(disks_on_file)
+    end
+
+    def local_path_image_allocation_preflight!
+        return if @options[:http_transfer]
+
+        puts 'Local PATH mode requires OneSwap to run on the OpenNebula frontend or work_dir to be shared at the same path.'
+
+        endpoint_host = opennebula_endpoint_host
+        return if endpoint_host.nil? || local_opennebula_endpoint?(endpoint_host)
+        return if @options[:allow_local_path_remote]
+
+        raise "OpenNebula endpoint host '#{endpoint_host}' appears to differ from this OneSwap worker. " \
+              'Local PATH image allocation would be resolved on the OpenNebula frontend and may not see worker-local files. ' \
+              'Enable http_transfer/http_host/http_port, run OneSwap on the frontend, share work_dir at the same path, ' \
+              'or pass --allow-local-path-remote if this path is intentionally shared.'
+    end
+
+    def opennebula_endpoint_host
+        endpoint = @options[:endpoint] || ENV['ONE_XMLRPC']
+        if endpoint.to_s.empty? && @client
+            endpoint = @client.endpoint if @client.respond_to?(:endpoint)
+            endpoint ||= @client.instance_variable_get(:@endpoint) if @client.instance_variable_defined?(:@endpoint)
+        end
+        endpoint = 'http://localhost:2633/RPC2' if endpoint.to_s.empty?
+
+        URI.parse(endpoint).host
+    rescue StandardError => e
+        @logger.warn "Unable to determine OpenNebula endpoint host: #{e.message}"
+        nil
+    end
+
+    def local_opennebula_endpoint?(host)
+        host = host.to_s.downcase
+        return true if host.empty?
+        return true if ['localhost', '127.0.0.1', '::1'].include?(host)
+        return true if host.start_with?('127.')
+
+        local_names = [Socket.gethostname]
+        begin
+            local_names << Socket.gethostbyname(Socket.gethostname).first
+        rescue StandardError
+            nil
+        end
+        local_names.compact!
+        local_names.map!(&:downcase)
+        return true if local_names.include?(host)
+
+        local_ips = Socket.ip_address_list.map(&:ip_address) rescue []
+        local_ips.include?(host)
     end
 
     def run_delta_prepare
@@ -1922,14 +1975,19 @@ _EOF_"
         total_time = copy_delta_time + apply_delta_time + os_morph_time +
             customization_time + import_time.to_f
 
-        puts "Current delta size: #{format_mib(delta_mib)}"
+        puts "Current delta size: #{format_mib(delta_mib)} (#{delta_info[:delta_size_source]})"
         if delta_info[:base_mib]
             puts "Prepared base disk size: #{format_mib(delta_info[:base_mib])}"
         else
             puts 'Prepared base disk size: unavailable'
         end
+        if delta_info[:delta_size_warning]
+            puts
+            puts delta_info[:delta_size_warning]
+        end
         puts
         puts 'Estimate basis:'
+        puts "  current delta size: #{delta_info[:delta_size_source]}"
         puts "  delta transfer: #{delta_info[:source_basis]}"
         puts "  delta apply: #{delta_info[:apply_basis]}"
         puts "  target import: #{delta_info[:import_basis]}"
@@ -2002,10 +2060,25 @@ _EOF_"
         vm = client.get_vm_by_name(@options[:name])
         return nil unless vm
 
-        bytes = vm.live2kvm_current_delta_size_bytes(@options[:work_dir])
-        return nil if bytes.nil?
-
         state = vm.live2kvm_state(@options[:work_dir]) || {}
+        delta_size = vm.live2kvm_current_delta_size(@options[:work_dir])
+        if delta_size.nil?
+            stored_bytes = state['delta_size_bytes'].to_i
+            return nil unless stored_bytes > 0
+
+            delta_size = {
+                :bytes => stored_bytes,
+                :source => 'stored prepare-time delta size',
+                :paths => [],
+                :refreshed => false,
+                :warning => 'Warning: unable to refresh live snapshot delta size from ESXi; using stored prepare-time value.'
+            }
+        end
+
+        delta_size[:paths].each do |path|
+            @logger.debug "Dry-run delta extent path: #{path}"
+        end
+
         measured_rate = state['base_transfer_mib_s'].to_f
         if measured_rate > 0
             source_rate = measured_rate
@@ -2034,23 +2107,28 @@ _EOF_"
 
         base_bytes = prepared_base_bytes(state)
         metrics = read_metrics
+        import_mode = opennebula_import_mode
         measured_import_rate = metrics['opennebula_import_mib_s'].to_f
         benchmark_import_rate = metrics['opennebula_import_benchmark_mib_s'].to_f
+        measured_import_mode = metrics['opennebula_import_mode']
+        benchmark_import_mode = metrics['opennebula_import_benchmark_mode']
         measured_import_mib = metrics['opennebula_import_bytes'].to_i.to_f / (1024 * 1024)
         measured_import_seconds = metrics['opennebula_import_seconds'].to_f
         benchmark_import_mib = metrics['opennebula_import_benchmark_bytes'].to_i.to_f / (1024 * 1024)
         benchmark_import_seconds = metrics['opennebula_import_benchmark_seconds'].to_f
-        if measured_import_rate > 0 && (benchmark_import_rate <= 0 || benchmark_import_mib < 1024)
+        measured_import_matches = measured_import_rate > 0 && measured_import_mode == import_mode
+        benchmark_import_matches = benchmark_import_rate > 0 && benchmark_import_mode == import_mode
+        if measured_import_matches && (!benchmark_import_matches || benchmark_import_mib < 1024)
             import_rate = measured_import_rate
             import_rate_source = :previous_full_import
             import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
             import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
-        elsif benchmark_import_rate > 0
+        elsif benchmark_import_matches
             import_rate = benchmark_import_rate
             import_rate_source = benchmark_import_mib >= 4096 ? :large_benchmark : :small_benchmark
             import_rate_label = benchmark_import_label(benchmark_import_mib, benchmark_import_seconds, import_rate)
             import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
-        elsif measured_import_rate > 0
+        elsif measured_import_matches
             import_rate = measured_import_rate
             import_rate_source = :previous_full_import
             import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
@@ -2058,8 +2136,8 @@ _EOF_"
         else
             import_rate = positive_float_option(:dry_run_target_import_mib_s)
             import_rate_source = :configured_fallback
-            import_rate_label = "configured fallback, not measured: #{import_rate.round(2)} MiB/s"
-            import_basis = "configured fallback, not measured, #{import_rate.round(2)} MiB/s"
+            import_rate_label = "configured fallback, not measured for #{import_mode} mode"
+            import_basis = "configured fallback, not measured for #{import_mode} mode, #{import_rate.round(2)} MiB/s"
         end
 
         measured_os_morph = positive_metric(metrics['delta_os_morph_seconds'])
@@ -2096,10 +2174,14 @@ _EOF_"
             customization_source,
             base_bytes
         )
+        confidence = 'low' unless delta_size[:refreshed]
         confidence_note = final_phase_fallback_note(os_morph_source, customization_source)
 
         {
-            :delta_mib => bytes.to_f / (1024 * 1024),
+            :delta_mib => delta_size[:bytes].to_f / (1024 * 1024),
+            :delta_size_source => delta_size[:source],
+            :delta_size_refreshed => delta_size[:refreshed],
+            :delta_size_warning => delta_size[:warning],
             :source_rate => source_rate,
             :source_rate_source => source_rate_source,
             :source_rate_label => source_rate_label,
@@ -2233,8 +2315,13 @@ _EOF_"
                           'opennebula_import_bytes' => bytes,
                           'opennebula_import_seconds' => seconds,
                           'opennebula_import_mib_s' => mib_per_second(bytes, seconds),
+                          'opennebula_import_mode' => opennebula_import_mode,
                           'customization_seconds' => customization_seconds
                       })
+    end
+
+    def opennebula_import_mode
+        @options[:http_transfer] ? 'http' : 'local-path'
     end
 
     def run_opennebula_import_benchmark
@@ -2245,7 +2332,8 @@ _EOF_"
 
         unless @options[:http_transfer]
             puts 'Warning: import benchmark skipped because http_transfer is not enabled.'
-            puts 'The dry-run estimate will use previous import metrics or dry_run_target_import_mib_s.'
+            puts 'HTTP benchmark metrics will not be reused for local-path mode.'
+            puts 'The dry-run estimate will use matching local-path import metrics or dry_run_target_import_mib_s.'
             return
         end
 
@@ -2295,6 +2383,7 @@ _EOF_"
                               'opennebula_import_benchmark_size_mib' => size_mib,
                               'opennebula_import_benchmark_seconds' => seconds,
                               'opennebula_import_benchmark_mib_s' => mib_s,
+                              'opennebula_import_benchmark_mode' => opennebula_import_mode,
                               'opennebula_import_benchmark_at' => Time.now.utc.iso8601,
                               'opennebula_import_benchmark_datastore' => ds_id
                           })
@@ -2380,6 +2469,11 @@ _EOF_"
     end
 
     def format_duration(seconds)
+        if seconds < 60
+            rounded = seconds.round(1)
+            return rounded == rounded.to_i ? "#{rounded.to_i}s" : "#{rounded}s"
+        end
+
         seconds = seconds.round
         hours = seconds / 3600
         minutes = (seconds % 3600) / 60
@@ -2679,6 +2773,7 @@ _EOF_"
                 'opennebula_import_bytes' => import_bytes,
                 'opennebula_import_seconds' => import_seconds,
                 'opennebula_import_mib_s' => import_mib_s,
+                'opennebula_import_mode' => opennebula_import_mode,
                 'customization_seconds' => customization_seconds
             }
 

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1839,6 +1839,7 @@ _EOF_"
 
         puts 'OneSwap dry-run estimate'
         puts "VM: #{@options[:name]}"
+        puts "Conversion mode: #{dry_run_conversion_mode}"
         puts "Disks: #{disks.length}"
         disks.each_with_index do |disk, index|
             puts "  disk #{index + 1}: provisioned #{format_mib(disk[:provisioned_mib])}, " \
@@ -1859,7 +1860,7 @@ _EOF_"
         puts "  import: #{format_duration(import_time)}"
         puts "  total: #{format_duration(export_time + conversion_time + import_time)}"
         puts
-        puts 'Warning: configured fallback throughput values are used.'
+        puts 'Warning: configured fallback throughput values are used. Actual runtime can differ depending on the selected transfer/conversion mode.'
     end
 
     def run_delta_dry_run_estimate
@@ -1875,11 +1876,15 @@ _EOF_"
 
         source_rate = positive_float_option(:dry_run_source_export_mib_s)
         import_rate = positive_float_option(:dry_run_target_import_mib_s)
-        downtime = delta_mib / [source_rate, import_rate].min
+        bottleneck_rate = [source_rate, import_rate].min
+        downtime = delta_mib / bottleneck_rate
 
-        puts "Known remaining delta size: #{format_mib(delta_mib)}"
-        puts "Bottleneck throughput: #{[source_rate, import_rate].min.round(2)} MiB/s"
+        puts "Current known delta size: #{format_mib(delta_mib)}"
+        puts "Source export fallback rate: #{source_rate.round(2)} MiB/s"
+        puts "Target import fallback rate: #{import_rate.round(2)} MiB/s"
+        puts "Bottleneck throughput: #{bottleneck_rate.round(2)} MiB/s"
         puts "Estimated downtime: #{format_duration(downtime)}"
+        puts 'Note: this is a point-in-time estimate. Delta size can continue growing while the VM is running.'
     end
 
     def dry_run_disk_metadata
@@ -1912,10 +1917,27 @@ _EOF_"
     end
 
     def dry_run_known_delta_mib
-        # The current delta implementation runs the full flow inside live2kvm:
-        # snapshot creation, base transfer/conversion, VM shutdown, and delta apply.
-        # There is no persisted base-phase state or known remaining delta size yet.
+        client = ESXi::Client.new(get_esxi_host, @logger, :non_interactive => true)
+        vm = client.get_vm_by_name(@options[:name])
+        return nil unless vm
+
+        bytes = vm.live2kvm_current_delta_size_bytes(@options[:work_dir])
+        return nil if bytes.nil?
+
+        bytes.to_f / (1024 * 1024)
+    rescue StandardError => e
+        @logger.warn "Unable to read prepared delta size: #{e.message}"
         nil
+    end
+
+    def dry_run_conversion_mode
+        return 'delta' if @options[:delta]
+        return 'custom' if @options[:custom_convert]
+        return 'hybrid' if @options[:hybrid]
+        return 'ESXi virt-v2v' if @options[:esxi_ip]
+        return 'vCenter VDDK virt-v2v' if @options[:vddk_path]
+
+        'vCenter API virt-v2v'
     end
 
     def positive_float_option(name)

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1806,18 +1806,39 @@ _EOF_"
 
     # Passworldess root access to ESXi host IP required
     def run_delta_conversion
-        client = ESXi::Client.new(get_esxi_host, @logger)
+        client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options)
 
         vm_name = @options[:name]
         vm = client.get_vm_by_name(vm_name)
 
-        conversion_dir = vm.live2kvm(@options[:work_dir])
+        conversion_dir = if @options[:delta_commit]
+                             vm.live2kvm_commit(@options[:work_dir])
+                         else
+                             vm.live2kvm(@options[:work_dir])
+                         end
 
         raise 'Failed to perform delta migration' unless conversion_dir
 
         disks_on_file = Dir.children(conversion_dir).map {|disk| File.join(conversion_dir, disk) }
 
         create_one_images(disks_on_file)
+    end
+
+    def run_delta_prepare
+        esxi_host = get_esxi_host
+        puts "Checking ESXi SSH/auth for #{@options[:esxi_user] || 'root'}@#{esxi_host}..."
+        client = ESXi::Client.new(esxi_host, @logger, esxi_client_options)
+        puts 'ESXi SSH/auth check completed.'
+
+        vm_name = @options[:name]
+        vm = client.get_vm_by_name(vm_name)
+
+        state = vm.live2kvm_prepare(@options[:work_dir])
+        raise 'Failed to prepare delta migration' unless state
+
+        state_file = File.join(state['transfer_dir'], 'oneswap-delta-state.yaml')
+        puts "Delta base phase prepared. State file: #{state_file}"
+        puts 'Warning: the VM snapshot remains active. Delta size can continue growing until --delta-commit is run.'
     end
 
     def run_dry_run_estimate
@@ -1917,7 +1938,7 @@ _EOF_"
     end
 
     def dry_run_known_delta_mib
-        client = ESXi::Client.new(get_esxi_host, @logger, :non_interactive => true)
+        client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options(:non_interactive => true))
         vm = client.get_vm_by_name(@options[:name])
         return nil unless vm
 
@@ -1928,6 +1949,13 @@ _EOF_"
     rescue StandardError => e
         @logger.warn "Unable to read prepared delta size: #{e.message}"
         nil
+    end
+
+    def esxi_client_options(extra = {})
+        {
+            :user => @options[:esxi_user] || 'root',
+            :password => @options[:esxi_pass]
+        }.merge(extra)
     end
 
     def dry_run_conversion_mode
@@ -3332,6 +3360,11 @@ GUESTFISH
         # OpenNebula system prechecks
         if !@options[:skip_prechecks]
             one_prechecks(vm)
+        end
+
+        if @options[:delta_prepare]
+            run_delta_prepare
+            return
         end
 
         # Gather NIC backing early because it makes a call to vCenter,

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -21,6 +21,9 @@ require 'fileutils'
 require 'shellwords'
 require 'tempfile'
 require 'tmpdir'
+require 'time'
+require 'webrick'
+require 'yaml'
 require_relative 'vsphere_client'
 require_relative 'esxi_vm'
 require_relative 'windows_tuner'
@@ -1841,6 +1844,16 @@ _EOF_"
         puts 'Warning: the VM snapshot remains active. Delta size can continue growing until --delta-commit is run.'
     end
 
+    def run_delta_cleanup
+        client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options)
+
+        vm_name = @options[:name]
+        vm = client.get_vm_by_name(vm_name)
+        raise "Unable to find VM #{vm_name} on ESXi host" unless vm
+
+        vm.live2kvm_cleanup(@options[:work_dir])
+    end
+
     def run_dry_run_estimate
         if @options[:delta]
             return run_delta_dry_run_estimate
@@ -1885,6 +1898,8 @@ _EOF_"
     end
 
     def run_delta_dry_run_estimate
+        run_opennebula_import_benchmark if @options[:benchmark_import]
+
         delta_info = dry_run_delta_info
 
         puts 'OneSwap dry-run delta estimate'
@@ -1897,16 +1912,55 @@ _EOF_"
 
         delta_mib = delta_info[:delta_mib]
         source_rate = delta_info[:source_rate]
-        import_rate = positive_float_option(:dry_run_target_import_mib_s)
-        bottleneck_rate = [source_rate, import_rate].min
-        downtime = delta_mib / bottleneck_rate
+        apply_rate = delta_info[:apply_rate]
+        import_rate = delta_info[:import_rate]
+        copy_delta_time = delta_mib / source_rate
+        apply_delta_time = delta_mib / apply_rate
+        import_time = delta_info[:base_mib] ? delta_info[:base_mib] / import_rate : nil
+        os_morph_time = delta_info[:os_morph_seconds]
+        customization_time = delta_info[:customization_seconds]
+        total_time = copy_delta_time + apply_delta_time + os_morph_time +
+            customization_time + import_time.to_f
 
-        puts "Current known delta size: #{format_mib(delta_mib)}"
-        puts "Source export #{delta_info[:source_rate_source]} rate: #{source_rate.round(2)} MiB/s"
-        puts "Target import fallback rate: #{import_rate.round(2)} MiB/s"
-        puts "Bottleneck throughput: #{bottleneck_rate.round(2)} MiB/s"
-        puts "Estimated downtime: #{format_duration(downtime)}"
-        puts 'Note: this is a point-in-time estimate. Delta size can continue growing while the VM is running.'
+        puts "Current delta size: #{format_mib(delta_mib)}"
+        if delta_info[:base_mib]
+            puts "Prepared base disk size: #{format_mib(delta_info[:base_mib])}"
+        else
+            puts 'Prepared base disk size: unavailable'
+        end
+        puts
+        puts 'Estimate basis:'
+        puts "  delta transfer: #{delta_info[:source_basis]}"
+        puts "  delta apply: #{delta_info[:apply_basis]}"
+        puts "  target import: #{delta_info[:import_basis]}"
+        puts "  OS morph: #{delta_info[:os_morph_basis]}"
+        puts "  guest customization: #{delta_info[:customization_basis]}"
+        puts
+        puts 'Rates:'
+        puts "  source/delta transfer: #{source_rate.round(2)} MiB/s (#{delta_info[:source_rate_label]})"
+        puts "  delta apply/conversion: #{apply_rate.round(2)} MiB/s (#{delta_info[:apply_rate_label]})"
+        puts "  target import: #{import_rate.round(2)} MiB/s (#{delta_info[:import_rate_label]})"
+        puts
+        puts 'Estimated final phase:'
+        puts "  copy remaining delta: #{format_duration(copy_delta_time)} (#{delta_info[:source_rate_label]})"
+        puts "  apply delta to prepared disk: #{format_duration(apply_delta_time)} (#{delta_info[:apply_rate_label]})"
+        puts "  virt-v2v-in-place / OS morph: #{format_duration(os_morph_time)} (#{delta_info[:os_morph_label]})"
+        puts "  guest customization: #{format_duration(customization_time)} (#{delta_info[:customization_label]})"
+        puts "  OpenNebula image import/copy: #{import_time ? format_duration(import_time) : 'not estimated'} (#{delta_info[:import_rate_label]})"
+        puts '  template creation: negligible'
+        puts "  total estimated downtime/import-ready time: #{format_duration(total_time)}"
+        puts "  confidence: #{delta_info[:confidence]}"
+        puts "  note: #{delta_info[:confidence_note]}" if delta_info[:confidence_note]
+        puts
+        puts 'Note: this is only an estimate. It does not run commit.'
+        puts 'The optional import benchmark creates and deletes a temporary OpenNebula image.'
+        puts 'Delta size can continue growing while the VM is running.'
+        puts 'If you want to continue now, run:'
+        puts "  oneswap convert #{@options[:name]} --delta --delta-commit"
+        puts 'If you only wanted timing data and will migrate later, run:'
+        puts "  oneswap convert #{@options[:name]} --delta --delta-cleanup"
+        puts "Then run normal `oneswap convert #{@options[:name]} --delta` during the selected maintenance window."
+        puts 'Do not leave the prepared snapshot active indefinitely, because the delta can grow very large.'
     end
 
     def dry_run_disk_metadata
@@ -1955,20 +2009,342 @@ _EOF_"
         measured_rate = state['base_transfer_mib_s'].to_f
         if measured_rate > 0
             source_rate = measured_rate
-            source_rate_source = 'measured prepare transfer'
+            source_rate_source = :prepare_measured
+            source_rate_label = 'measured during prepare'
+            source_basis = "measured during prepare, #{source_rate.round(2)} MiB/s"
         else
             source_rate = positive_float_option(:dry_run_source_export_mib_s)
-            source_rate_source = 'fallback'
+            source_rate_source = :configured_fallback
+            source_rate_label = 'configured fallback, not measured'
+            source_basis = "configured fallback, not measured, #{source_rate.round(2)} MiB/s"
         end
+
+        measured_apply_rate = state['base_convert_mib_s'].to_f
+        if measured_apply_rate > 0
+            apply_rate = measured_apply_rate
+            apply_rate_source = :prepare_measured
+            apply_rate_label = 'measured during prepare'
+            apply_basis = "measured during prepare, #{apply_rate.round(2)} MiB/s"
+        else
+            apply_rate = positive_float_option(:dry_run_qcow2_conversion_mib_s)
+            apply_rate_source = :configured_fallback
+            apply_rate_label = 'configured fallback, not measured'
+            apply_basis = "configured fallback, not measured, #{apply_rate.round(2)} MiB/s"
+        end
+
+        base_bytes = prepared_base_bytes(state)
+        metrics = read_metrics
+        measured_import_rate = metrics['opennebula_import_mib_s'].to_f
+        benchmark_import_rate = metrics['opennebula_import_benchmark_mib_s'].to_f
+        measured_import_mib = metrics['opennebula_import_bytes'].to_i.to_f / (1024 * 1024)
+        measured_import_seconds = metrics['opennebula_import_seconds'].to_f
+        benchmark_import_mib = metrics['opennebula_import_benchmark_bytes'].to_i.to_f / (1024 * 1024)
+        benchmark_import_seconds = metrics['opennebula_import_benchmark_seconds'].to_f
+        if measured_import_rate > 0 && (benchmark_import_rate <= 0 || benchmark_import_mib < 1024)
+            import_rate = measured_import_rate
+            import_rate_source = :previous_full_import
+            import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
+            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
+        elsif benchmark_import_rate > 0
+            import_rate = benchmark_import_rate
+            import_rate_source = benchmark_import_mib >= 4096 ? :large_benchmark : :small_benchmark
+            import_rate_label = benchmark_import_label(benchmark_import_mib, benchmark_import_seconds, import_rate)
+            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
+        elsif measured_import_rate > 0
+            import_rate = measured_import_rate
+            import_rate_source = :previous_full_import
+            import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
+            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
+        else
+            import_rate = positive_float_option(:dry_run_target_import_mib_s)
+            import_rate_source = :configured_fallback
+            import_rate_label = "configured fallback, not measured: #{import_rate.round(2)} MiB/s"
+            import_basis = "configured fallback, not measured, #{import_rate.round(2)} MiB/s"
+        end
+
+        measured_os_morph = positive_metric(metrics['delta_os_morph_seconds'])
+        if measured_os_morph
+            os_morph_seconds = measured_os_morph
+            os_morph_source = :previous_metrics
+            os_morph_label = 'previous full run'
+            os_morph_basis = "previous full run, #{format_duration(os_morph_seconds)}"
+        else
+            os_morph_seconds = positive_float_option(:dry_run_delta_os_morph_seconds)
+            os_morph_source = :configured_fallback
+            os_morph_label = 'configured fallback'
+            os_morph_basis = "configured fallback, #{os_morph_seconds.round}s"
+        end
+
+        measured_customization = positive_metric(metrics['customization_seconds'])
+        if measured_customization
+            customization_seconds = measured_customization
+            customization_source = :previous_metrics
+            customization_label = 'previous full run'
+            customization_basis = "previous full run, #{format_duration(customization_seconds)}"
+        else
+            customization_seconds = positive_float_option(:dry_run_guest_customization_seconds)
+            customization_source = :configured_fallback
+            customization_label = 'configured fallback'
+            customization_basis = "configured fallback, #{customization_seconds.round}s"
+        end
+
+        confidence = estimate_confidence(
+            source_rate_source,
+            apply_rate_source,
+            import_rate_source,
+            os_morph_source,
+            customization_source,
+            base_bytes
+        )
+        confidence_note = final_phase_fallback_note(os_morph_source, customization_source)
 
         {
             :delta_mib => bytes.to_f / (1024 * 1024),
             :source_rate => source_rate,
-            :source_rate_source => source_rate_source
+            :source_rate_source => source_rate_source,
+            :source_rate_label => source_rate_label,
+            :source_basis => source_basis,
+            :apply_rate => apply_rate,
+            :apply_rate_source => apply_rate_source,
+            :apply_rate_label => apply_rate_label,
+            :apply_basis => apply_basis,
+            :import_rate => import_rate,
+            :import_rate_source => import_rate_source,
+            :import_rate_label => import_rate_label,
+            :import_basis => import_basis,
+            :base_mib => base_bytes && base_bytes.to_f / (1024 * 1024),
+            :os_morph_seconds => os_morph_seconds,
+            :os_morph_source => os_morph_source,
+            :os_morph_label => os_morph_label,
+            :os_morph_basis => os_morph_basis,
+            :customization_seconds => customization_seconds,
+            :customization_source => customization_source,
+            :customization_label => customization_label,
+            :customization_basis => customization_basis,
+            :confidence => confidence,
+            :confidence_note => confidence_note
         }
     rescue StandardError => e
         @logger.warn "Unable to read prepared delta size: #{e.message}"
         nil
+    end
+
+    def positive_metric(value)
+        value = value.to_f
+        value > 0 ? value : nil
+    end
+
+    def estimate_confidence(source_rate_source, apply_rate_source, import_rate_source,
+                            os_morph_source, customization_source, base_bytes)
+        prepare_measured = source_rate_source == :prepare_measured &&
+            apply_rate_source == :prepare_measured
+        import_strong = [:previous_full_import, :large_benchmark].include?(import_rate_source)
+        import_usable = import_strong ||
+            [:configured_fallback, :small_benchmark].include?(import_rate_source)
+        final_phase_measured = os_morph_source == :previous_metrics &&
+            customization_source == :previous_metrics
+        final_phase_accounted = [:previous_metrics, :configured_fallback].include?(os_morph_source) &&
+            [:previous_metrics, :configured_fallback].include?(customization_source) &&
+            !base_bytes.nil?
+
+        return 'high' if prepare_measured && import_strong && final_phase_measured && final_phase_accounted
+        return 'medium' if prepare_measured && import_usable && final_phase_accounted
+
+        'low'
+    end
+
+    def final_phase_fallback_note(os_morph_source, customization_source)
+        fallback_phases = []
+        fallback_phases << 'OS morph' if os_morph_source == :configured_fallback
+        fallback_phases << 'guest customization' if customization_source == :configured_fallback
+        return nil if fallback_phases.empty?
+
+        "#{fallback_phases.join(' and ')} #{fallback_phases.size == 1 ? 'is' : 'are'} fallback estimates until a successful commit records real timings."
+    end
+
+    def previous_import_label(size_mib, seconds, rate)
+        if size_mib > 0 && seconds > 0
+            "previous full import: #{format_mib(size_mib)} in #{format_duration(seconds)}"
+        else
+            "previous full import: #{rate.round(2)} MiB/s"
+        end
+    end
+
+    def benchmark_import_label(size_mib, seconds, rate)
+        label = if size_mib > 0
+                    "measured benchmark: #{format_mib(size_mib)}"
+                else
+                    "measured benchmark: #{rate.round(2)} MiB/s"
+                end
+        label += " in #{format_duration(seconds)}" if seconds > 0
+        label
+    end
+
+    def prepared_base_bytes(state)
+        bytes = state['base_convert_bytes'].to_i
+        return bytes if bytes > 0
+
+        disks = state['disks']
+        return nil unless disks.is_a?(Array)
+
+        total = 0
+        disks.each do |disk|
+            path = disk['converted_raw_base_path']
+            return nil unless path && File.exist?(path)
+
+            total += File.size(path)
+        end
+
+        total > 0 ? total : nil
+    end
+
+    def metrics_file
+        File.join(@options[:work_dir], 'oneswap-metrics.yaml')
+    end
+
+    def delta_state_file
+        File.join(@options[:work_dir], "esxi_client-#{@options[:name]}", 'oneswap-delta-state.yaml')
+    end
+
+    def read_metrics
+        return {} unless File.exist?(metrics_file)
+
+        YAML.load_file(metrics_file) || {}
+    rescue StandardError => e
+        @logger.warn "Unable to read metrics file #{metrics_file}: #{e.message}"
+        {}
+    end
+
+    def write_metrics(metrics)
+        File.write(metrics_file, read_metrics.merge(metrics).to_yaml)
+    rescue StandardError => e
+        @logger.warn "Unable to write metrics file #{metrics_file}: #{e.message}"
+    end
+
+    def persist_opennebula_import_metrics(import_metrics)
+        return if import_metrics.empty?
+
+        bytes = import_metrics.sum {|m| m['opennebula_import_bytes'].to_i }
+        seconds = import_metrics.sum {|m| m['opennebula_import_seconds'].to_f }
+        customization_seconds = import_metrics.sum {|m| m['customization_seconds'].to_f }
+
+        write_metrics({
+                          'opennebula_imports' => import_metrics,
+                          'opennebula_import_bytes' => bytes,
+                          'opennebula_import_seconds' => seconds,
+                          'opennebula_import_mib_s' => mib_per_second(bytes, seconds),
+                          'customization_seconds' => customization_seconds
+                      })
+    end
+
+    def run_opennebula_import_benchmark
+        unless File.exist?(delta_state_file)
+            puts "Warning: import benchmark skipped because prepared delta state was not found at #{delta_state_file}."
+            return
+        end
+
+        unless @options[:http_transfer]
+            puts 'Warning: import benchmark skipped because http_transfer is not enabled.'
+            puts 'The dry-run estimate will use previous import metrics or dry_run_target_import_mib_s.'
+            return
+        end
+
+        size_mib = positive_float_option(:dry_run_import_benchmark_size_mib)
+        benchmark_dir = File.join(@options[:work_dir], 'dry-run-import-benchmark')
+        FileUtils.mkdir_p(benchmark_dir)
+        test_file = File.join(benchmark_dir, "#{@options[:name]}-import-benchmark.raw")
+        bytes = (size_mib * 1024 * 1024).to_i
+
+        puts "Running OpenNebula import benchmark with #{format_mib(size_mib)} temporary raw file."
+        if size_mib < 1024
+            puts 'Warning: benchmark size is below 1024 MiB. OpenNebula fixed allocation/datastore/polling overhead can dominate small imports and make the result pessimistic.'
+        end
+        puts 'Writing non-sparse benchmark file with real zero-filled data.'
+        write_benchmark_file(test_file, bytes)
+
+        server_thread = nil
+        img = nil
+        begin
+            server_thread = start_http_transfer_server(benchmark_dir)
+            path = "http://#{@options[:http_host]}:#{@options[:http_port]}/#{File.basename(test_file)}"
+            img = OpenNebula::Image.new(OpenNebula::Image.build_xml, @client)
+            img.add_element('//IMAGE', {
+                                'NAME' => "#{@options[:name]}_dry_run_import_benchmark_#{Time.now.to_i}",
+                'TYPE' => 'DATABLOCK',
+                'PATH' => path,
+                'PERSISTENT' => 'NO'
+                            })
+
+            ds_id = @options[:datastore].to_s.split(',').map(&:strip).map(&:to_i).first
+            import_t0 = Time.now
+            rc = img.allocate(img.to_xml, ds_id)
+            if rc.class == OpenNebula::Error
+                raise "OpenNebula image allocation failed: #{rc.message}"
+            end
+
+            puts 'Waiting for benchmark image to be ready.'
+            img_wait_sec = @options[:img_wait] || 120
+            unless img.wait_state('READY', img_wait_sec)
+                raise "benchmark image did not become READY before #{img_wait_sec}s timeout"
+            end
+
+            seconds = Time.now - import_t0
+            mib_s = mib_per_second(bytes, seconds)
+            write_metrics({
+                              'opennebula_import_benchmark_bytes' => bytes,
+                              'opennebula_import_benchmark_size_mib' => size_mib,
+                              'opennebula_import_benchmark_seconds' => seconds,
+                              'opennebula_import_benchmark_mib_s' => mib_s,
+                              'opennebula_import_benchmark_at' => Time.now.utc.iso8601,
+                              'opennebula_import_benchmark_datastore' => ds_id
+                          })
+
+            puts "OpenNebula import benchmark: #{format_mib(size_mib)} in " \
+                 "#{format_duration(seconds)} (#{mib_s.round(2)} MiB/s)"
+        rescue StandardError => e
+            puts "Warning: import benchmark failed: #{e.message}"
+            puts 'The dry-run estimate will use previous import metrics or dry_run_target_import_mib_s.'
+        ensure
+            begin
+                img.delete if img && img.id
+            rescue StandardError => e
+                puts "Warning: unable to delete benchmark image #{img.id}: #{e.message}" if img && img.id
+            end
+            if server_thread
+                server_thread.kill
+                server_thread.join
+            end
+            FileUtils.rm_f(test_file)
+        end
+    end
+
+    def start_http_transfer_server(document_root)
+        Thread.new do
+            server = WEBrick::HTTPServer.new({
+                                                 :Port => @options[:http_port],
+                :DocumentRoot => document_root,
+                :RequestCallback => lambda {|_req, res|
+                    res['Cache-Control'] = 'public, max-age=3600'
+                },
+                :MaxThreads => 8
+                                             })
+
+            trap('INT') { server.shutdown }
+            server.start
+        end.tap { sleep 0.2 }
+    end
+
+    def write_benchmark_file(path, bytes)
+        chunk = "\0" * (1024 * 1024)
+        remaining = bytes
+
+        File.open(path, 'wb') do |file|
+            while remaining > 0
+                write_size = [remaining, chunk.bytesize].min
+                file.write(write_size == chunk.bytesize ? chunk : chunk.byteslice(0, write_size))
+                remaining -= write_size
+            end
+        end
     end
 
     def esxi_client_options(extra = {})
@@ -2016,6 +2392,12 @@ _EOF_"
         else
             format('%ds', secs)
         end
+    end
+
+    def mib_per_second(bytes, seconds)
+        return nil if bytes.to_i <= 0 || seconds.to_f <= 0
+
+        (bytes.to_f / (1024 * 1024)) / seconds.to_f
     end
 
     # Create and run the qemu-img vmdk conversion
@@ -2203,12 +2585,14 @@ _EOF_"
         img_ids = []
         persistent_image = @options[:persistent_img] ? 'YES' : 'NO'
         t0 = Time.now
+        import_metrics = []
 
         # Normalize datastore input to an array of integers
         datastores = @options[:datastore].to_s.split(',').map(&:strip).map(&:to_i)
 
         disks.each_with_index do |d, i|
             img = OpenNebula::Image.new(OpenNebula::Image.build_xml, @client)
+            customization_t0 = Time.now
             guest_info = detect_distro(d)
             os_name = false
             begin
@@ -2228,9 +2612,11 @@ _EOF_"
                     puts "#{e.message}"
                 end
             end
+            customization_seconds = Time.now - customization_t0
 
             if @options[:http_transfer]
                 path = "http://#{@options[:http_host]}:#{@options[:http_port]}/#{File.basename(d)}"
+                puts "Using HTTP transfer for image #{i}: #{path}"
                 server_thread = Thread.new do
                     server = WEBrick::HTTPServer.new({
                                                          :Port => @options[:http_port],
@@ -2260,6 +2646,7 @@ _EOF_"
 
             # Pick datastore index if available, else default to the first one
             ds_id = datastores[i] || datastores.first
+            import_t0 = Time.now
             rc = img.allocate(img.to_xml, ds_id)
 
             if rc.class == OpenNebula::Error
@@ -2280,6 +2667,21 @@ _EOF_"
                 puts 'Image Short State: ' + img.short_state_str
             end
 
+            import_seconds = Time.now - import_t0
+            import_bytes = File.exist?(d) ? File.size(d) : 0
+            import_mib_s = mib_per_second(import_bytes, import_seconds)
+            if import_mib_s
+                puts "OpenNebula import for image #{i}: #{format_mib(import_bytes.to_f / (1024 * 1024))} " \
+                     "in #{format_duration(import_seconds)} (#{import_mib_s.round(2)} MiB/s)"
+            end
+            import_metrics << {
+                'disk' => d,
+                'opennebula_import_bytes' => import_bytes,
+                'opennebula_import_seconds' => import_seconds,
+                'opennebula_import_mib_s' => import_mib_s,
+                'customization_seconds' => customization_seconds
+            }
+
             if @options[:http_transfer]
                 server_thread.kill
                 server_thread.join
@@ -2288,6 +2690,7 @@ _EOF_"
             img_ids.append({ :id => img.id, :os => os_name })
         end
 
+        persist_opennebula_import_metrics(import_metrics)
         puts "Allocated images in OpenNebula in (#{(Time.now - t0).round(2)}s)".green
 
         img_ids
@@ -3384,6 +3787,11 @@ GUESTFISH
 
         if @options[:delta_prepare]
             run_delta_prepare
+            return
+        end
+
+        if @options[:delta_cleanup]
+            run_delta_cleanup
             return
         end
 

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1912,17 +1912,27 @@ _EOF_"
             return run_delta_dry_run_estimate
         end
 
+        run_opennebula_import_benchmark if @options[:benchmark_import]
+
         disks = dry_run_disk_metadata
         total_provisioned_mib = disks.sum {|disk| disk[:provisioned_mib] }
         total_data_mib = disks.sum {|disk| disk[:estimated_data_mib] }
 
         source_rate = positive_float_option(:dry_run_source_export_mib_s)
+        source_rate_label = 'configured fallback, not measured'
+        source_basis = "configured fallback, not measured, #{source_rate.round(2)} MiB/s"
         convert_rate = positive_float_option(:dry_run_qcow2_conversion_mib_s)
-        import_rate = positive_float_option(:dry_run_target_import_mib_s)
+        convert_rate_label = 'configured fallback, not measured'
+        convert_basis = "configured fallback, not measured, #{convert_rate.round(2)} MiB/s"
+        import_info = target_import_estimate(:prefer_previous_full => true)
+        import_rate = import_info[:rate]
 
         export_time = total_data_mib / source_rate
         conversion_time = total_data_mib / convert_rate
         import_time = total_data_mib / import_rate
+        confidence = regular_dry_run_confidence(:configured_fallback,
+                                                :configured_fallback,
+                                                import_info[:source])
 
         puts 'OneSwap dry-run estimate'
         puts "VM: #{@options[:name]}"
@@ -1936,18 +1946,24 @@ _EOF_"
         puts "Total provisioned size: #{format_mib(total_provisioned_mib)}"
         puts "Estimated data size: #{format_mib(total_data_mib)}"
         puts
-        puts 'Throughput assumptions:'
-        puts "  source export: #{source_rate.round(2)} MiB/s"
-        puts "  qcow2 conversion: #{convert_rate.round(2)} MiB/s"
-        puts "  target import: #{import_rate.round(2)} MiB/s"
+        puts 'Estimate basis:'
+        puts "  source export: #{source_basis}"
+        puts "  conversion: #{convert_basis}"
+        puts "  target import: #{import_info[:basis]}"
+        puts
+        puts 'Rates:'
+        puts "  source export: #{source_rate.round(2)} MiB/s (#{source_rate_label})"
+        puts "  conversion: #{convert_rate.round(2)} MiB/s (#{convert_rate_label})"
+        puts "  target import: #{import_rate.round(2)} MiB/s (#{import_info[:label]})"
         puts
         puts 'Estimated phase durations:'
         puts "  export: #{format_duration(export_time)}"
         puts "  conversion: #{format_duration(conversion_time)}"
         puts "  import: #{format_duration(import_time)}"
         puts "  total: #{format_duration(export_time + conversion_time + import_time)}"
+        puts "  confidence: #{confidence}"
         puts
-        puts 'Warning: configured fallback throughput values are used. Actual runtime can differ depending on the selected transfer/conversion mode.'
+        puts 'Warning: source export and conversion use configured fallback values unless previous matching regular conversion metrics are available.'
     end
 
     def run_delta_dry_run_estimate
@@ -2107,38 +2123,11 @@ _EOF_"
 
         base_bytes = prepared_base_bytes(state)
         metrics = read_metrics
-        import_mode = opennebula_import_mode
-        measured_import_rate = metrics['opennebula_import_mib_s'].to_f
-        benchmark_import_rate = metrics['opennebula_import_benchmark_mib_s'].to_f
-        measured_import_mode = metrics['opennebula_import_mode']
-        benchmark_import_mode = metrics['opennebula_import_benchmark_mode']
-        measured_import_mib = metrics['opennebula_import_bytes'].to_i.to_f / (1024 * 1024)
-        measured_import_seconds = metrics['opennebula_import_seconds'].to_f
-        benchmark_import_mib = metrics['opennebula_import_benchmark_bytes'].to_i.to_f / (1024 * 1024)
-        benchmark_import_seconds = metrics['opennebula_import_benchmark_seconds'].to_f
-        measured_import_matches = measured_import_rate > 0 && measured_import_mode == import_mode
-        benchmark_import_matches = benchmark_import_rate > 0 && benchmark_import_mode == import_mode
-        if measured_import_matches && (!benchmark_import_matches || benchmark_import_mib < 1024)
-            import_rate = measured_import_rate
-            import_rate_source = :previous_full_import
-            import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
-            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
-        elsif benchmark_import_matches
-            import_rate = benchmark_import_rate
-            import_rate_source = benchmark_import_mib >= 4096 ? :large_benchmark : :small_benchmark
-            import_rate_label = benchmark_import_label(benchmark_import_mib, benchmark_import_seconds, import_rate)
-            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
-        elsif measured_import_matches
-            import_rate = measured_import_rate
-            import_rate_source = :previous_full_import
-            import_rate_label = previous_import_label(measured_import_mib, measured_import_seconds, import_rate)
-            import_basis = "#{import_rate_label}, #{import_rate.round(2)} MiB/s"
-        else
-            import_rate = positive_float_option(:dry_run_target_import_mib_s)
-            import_rate_source = :configured_fallback
-            import_rate_label = "configured fallback, not measured for #{import_mode} mode"
-            import_basis = "configured fallback, not measured for #{import_mode} mode, #{import_rate.round(2)} MiB/s"
-        end
+        import_info = target_import_estimate(:metrics => metrics, :prefer_previous_full => false)
+        import_rate = import_info[:rate]
+        import_rate_source = import_info[:source]
+        import_rate_label = import_info[:label]
+        import_basis = import_info[:basis]
 
         measured_os_morph = positive_metric(metrics['delta_os_morph_seconds'])
         if measured_os_morph
@@ -2214,6 +2203,71 @@ _EOF_"
     def positive_metric(value)
         value = value.to_f
         value > 0 ? value : nil
+    end
+
+    def target_import_estimate(metrics: read_metrics, prefer_previous_full: true)
+        import_mode = opennebula_import_mode
+        measured_import_rate = metrics['opennebula_import_mib_s'].to_f
+        benchmark_import_rate = metrics['opennebula_import_benchmark_mib_s'].to_f
+        measured_import_mode = metrics['opennebula_import_mode']
+        benchmark_import_mode = metrics['opennebula_import_benchmark_mode']
+        measured_import_mib = metrics['opennebula_import_bytes'].to_i.to_f / (1024 * 1024)
+        measured_import_seconds = metrics['opennebula_import_seconds'].to_f
+        benchmark_import_mib = metrics['opennebula_import_benchmark_bytes'].to_i.to_f / (1024 * 1024)
+        benchmark_import_seconds = metrics['opennebula_import_benchmark_seconds'].to_f
+        measured_import_matches = measured_import_rate > 0 && measured_import_mode == import_mode
+        benchmark_import_matches = benchmark_import_rate > 0 && benchmark_import_mode == import_mode
+
+        if measured_import_matches && (prefer_previous_full || !benchmark_import_matches || benchmark_import_mib < 1024)
+            label = previous_import_label(measured_import_mib, measured_import_seconds, measured_import_rate)
+            return {
+                :rate => measured_import_rate,
+                :source => :previous_full_import,
+                :label => label,
+                :basis => "#{label}, #{measured_import_rate.round(2)} MiB/s"
+            }
+        end
+
+        if benchmark_import_matches
+            source = benchmark_import_mib >= 4096 ? :large_benchmark : :small_benchmark
+            label = benchmark_import_label(benchmark_import_mib, benchmark_import_seconds, benchmark_import_rate)
+            return {
+                :rate => benchmark_import_rate,
+                :source => source,
+                :label => label,
+                :basis => "#{label}, #{benchmark_import_rate.round(2)} MiB/s"
+            }
+        end
+
+        if measured_import_matches
+            label = previous_import_label(measured_import_mib, measured_import_seconds, measured_import_rate)
+            return {
+                :rate => measured_import_rate,
+                :source => :previous_full_import,
+                :label => label,
+                :basis => "#{label}, #{measured_import_rate.round(2)} MiB/s"
+            }
+        end
+
+        rate = positive_float_option(:dry_run_target_import_mib_s)
+        label = "configured fallback, not measured for #{import_mode} mode"
+        {
+            :rate => rate,
+            :source => :configured_fallback,
+            :label => label,
+            :basis => "#{label}, #{rate.round(2)} MiB/s"
+        }
+    end
+
+    def regular_dry_run_confidence(source_rate_source, convert_rate_source, import_rate_source)
+        source_measured = source_rate_source == :previous_metrics
+        convert_measured = convert_rate_source == :previous_metrics
+        import_measured = [:previous_full_import, :large_benchmark, :small_benchmark].include?(import_rate_source)
+
+        return 'high' if source_measured && convert_measured && import_measured
+        return 'medium' if import_measured
+
+        'low'
     end
 
     def estimate_confidence(source_rate_source, apply_rate_source, import_rate_source,
@@ -2325,7 +2379,7 @@ _EOF_"
     end
 
     def run_opennebula_import_benchmark
-        unless File.exist?(delta_state_file)
+        if @options[:delta] && !File.exist?(delta_state_file)
             puts "Warning: import benchmark skipped because prepared delta state was not found at #{delta_state_file}."
             return
         end

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1922,6 +1922,7 @@ _EOF_"
         source_info = source_export_estimate
         source_rate = source_info[:rate]
         convert_rate = positive_float_option(:dry_run_qcow2_conversion_mib_s)
+        convert_rate_source = :configured_fallback
         convert_rate_label = 'configured fallback, not measured'
         convert_basis = "configured fallback, not measured, #{convert_rate.round(2)} MiB/s"
         import_info = target_import_estimate(:prefer_previous_full => true)
@@ -1962,8 +1963,14 @@ _EOF_"
         puts "  import: #{format_duration(import_time)}"
         puts "  total: #{format_duration(export_time + conversion_time + import_time)}"
         puts "  confidence: #{confidence}"
-        puts
-        puts 'Warning: source export and conversion use configured fallback values unless previous matching regular conversion metrics are available.'
+
+        fallback_phases = []
+        fallback_phases << 'source export' if source_info[:source] == :configured_fallback
+        fallback_phases << 'conversion' if convert_rate_source == :configured_fallback
+        unless fallback_phases.empty?
+            puts
+            puts "Warning: #{fallback_phases.join(' and ')} #{fallback_phases.length == 1 ? 'uses' : 'use'} configured fallback values unless previous matching regular conversion metrics are available."
+        end
     end
 
     def run_delta_dry_run_estimate
@@ -2253,7 +2260,9 @@ _EOF_"
         measured_import_seconds = metrics['opennebula_import_seconds'].to_f
         benchmark_import_mib = metrics['opennebula_import_benchmark_bytes'].to_i.to_f / (1024 * 1024)
         benchmark_import_seconds = metrics['opennebula_import_benchmark_seconds'].to_f
-        measured_import_matches = measured_import_rate > 0 && measured_import_mode == import_mode
+        measured_import_matches = measured_import_rate > 0 &&
+            measured_import_mode == import_mode &&
+            measured_import_mode != 'http'
         benchmark_import_matches = benchmark_import_rate > 0 && benchmark_import_mode == import_mode
 
         if measured_import_matches && (prefer_previous_full || !benchmark_import_matches || benchmark_import_mib < 1024)
@@ -2399,8 +2408,9 @@ _EOF_"
         {}
     end
 
-    def write_metrics(metrics)
-        File.write(metrics_file, read_metrics.merge(metrics).to_yaml)
+    def write_metrics(metrics, replace: false)
+        data = replace ? metrics : read_metrics.merge(metrics)
+        File.write(metrics_file, data.to_yaml)
     rescue StandardError => e
         @logger.warn "Unable to write metrics file #{metrics_file}: #{e.message}"
     end
@@ -2408,18 +2418,35 @@ _EOF_"
     def persist_opennebula_import_metrics(import_metrics)
         return if import_metrics.empty?
 
-        bytes = import_metrics.sum {|m| m['opennebula_import_bytes'].to_i }
-        seconds = import_metrics.sum {|m| m['opennebula_import_seconds'].to_f }
         customization_seconds = import_metrics.sum {|m| m['customization_seconds'].to_f }
+        metrics = { 'customization_seconds' => customization_seconds }
 
-        write_metrics({
-                          'opennebula_imports' => import_metrics,
-                          'opennebula_import_bytes' => bytes,
-                          'opennebula_import_seconds' => seconds,
-                          'opennebula_import_mib_s' => mib_per_second(bytes, seconds),
-                          'opennebula_import_mode' => opennebula_import_mode,
-                          'customization_seconds' => customization_seconds
-                      })
+        reusable_import_metrics = import_metrics.select {|m| m['opennebula_import_seconds'].to_f > 0 }
+        unless reusable_import_metrics.empty?
+            bytes = reusable_import_metrics.sum {|m| m['opennebula_import_bytes'].to_i }
+            seconds = reusable_import_metrics.sum {|m| m['opennebula_import_seconds'].to_f }
+            metrics.merge!({
+                               'opennebula_imports' => reusable_import_metrics,
+                               'opennebula_import_bytes' => bytes,
+                               'opennebula_import_seconds' => seconds,
+                               'opennebula_import_mib_s' => mib_per_second(bytes, seconds),
+                               'opennebula_import_mode' => opennebula_import_mode
+                           })
+        else
+            current = read_metrics
+            [
+                'opennebula_imports',
+                'opennebula_import_bytes',
+                'opennebula_import_seconds',
+                'opennebula_import_mib_s',
+                'opennebula_import_mode'
+            ].each {|key| current.delete(key) }
+
+            write_metrics(current.merge(metrics), :replace => true)
+            return
+        end
+
+        write_metrics(metrics)
     end
 
     def opennebula_import_mode
@@ -2935,25 +2962,40 @@ _EOF_"
                 puts 'Image Short State: ' + img.short_state_str
             end
 
-            import_seconds = Time.now - import_t0
+            ready_wait_seconds = Time.now - import_t0
+            puts "OpenNebula image #{i} READY wait: #{format_duration(ready_wait_seconds)}"
             import_bytes = File.exist?(d) ? File.size(d) : 0
-            import_mib_s = mib_per_second(import_bytes, import_seconds)
-            if import_mib_s
-                puts "OpenNebula import for image #{i}: #{format_mib(import_bytes.to_f / (1024 * 1024))} " \
-                     "in #{format_duration(import_seconds)} (#{import_mib_s.round(2)} MiB/s)"
-            end
-            import_metrics << {
-                'disk' => d,
-                'opennebula_import_bytes' => import_bytes,
-                'opennebula_import_seconds' => import_seconds,
-                'opennebula_import_mib_s' => import_mib_s,
-                'opennebula_import_mode' => opennebula_import_mode,
-                'customization_seconds' => customization_seconds
-            }
 
             if @options[:http_transfer]
                 server_thread.kill
                 server_thread.join
+            end
+
+            import_seconds = Time.now - import_t0
+            import_mib_s = mib_per_second(import_bytes, import_seconds)
+            if @options[:http_transfer]
+                puts "HTTP transfer/server completion for image #{i}: #{format_duration(import_seconds)}"
+                puts "Observed HTTP import timing for image #{i} is not persisted as a reusable metric; use --dry-run --benchmark-import for trusted HTTP import metrics."
+            end
+            if import_mib_s
+                puts "OpenNebula import for image #{i}: #{format_mib(import_bytes.to_f / (1024 * 1024))} " \
+                     "in #{format_duration(import_seconds)} (#{import_mib_s.round(2)} MiB/s)"
+            end
+            if @options[:http_transfer]
+                import_metrics << {
+                    'disk' => d,
+                    'customization_seconds' => customization_seconds
+                }
+            else
+                import_metrics << {
+                    'disk' => d,
+                    'opennebula_import_bytes' => import_bytes,
+                    'opennebula_import_seconds' => import_seconds,
+                    'opennebula_import_ready_seconds' => ready_wait_seconds,
+                    'opennebula_import_mib_s' => import_mib_s,
+                    'opennebula_import_mode' => opennebula_import_mode,
+                    'customization_seconds' => customization_seconds
+                }
             end
 
             img_ids.append({ :id => img.id, :os => os_name })

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1885,23 +1885,24 @@ _EOF_"
     end
 
     def run_delta_dry_run_estimate
-        delta_mib = dry_run_known_delta_mib
+        delta_info = dry_run_delta_info
 
         puts 'OneSwap dry-run delta estimate'
         puts "VM: #{@options[:name]}"
 
-        if delta_mib.nil?
+        if delta_info.nil?
             puts 'Downtime estimate is not available. The remaining delta size is only known after the base phase has been completed.'
             return
         end
 
-        source_rate = positive_float_option(:dry_run_source_export_mib_s)
+        delta_mib = delta_info[:delta_mib]
+        source_rate = delta_info[:source_rate]
         import_rate = positive_float_option(:dry_run_target_import_mib_s)
         bottleneck_rate = [source_rate, import_rate].min
         downtime = delta_mib / bottleneck_rate
 
         puts "Current known delta size: #{format_mib(delta_mib)}"
-        puts "Source export fallback rate: #{source_rate.round(2)} MiB/s"
+        puts "Source export #{delta_info[:source_rate_source]} rate: #{source_rate.round(2)} MiB/s"
         puts "Target import fallback rate: #{import_rate.round(2)} MiB/s"
         puts "Bottleneck throughput: #{bottleneck_rate.round(2)} MiB/s"
         puts "Estimated downtime: #{format_duration(downtime)}"
@@ -1938,6 +1939,11 @@ _EOF_"
     end
 
     def dry_run_known_delta_mib
+        info = dry_run_delta_info
+        info && info[:delta_mib]
+    end
+
+    def dry_run_delta_info
         client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options(:non_interactive => true))
         vm = client.get_vm_by_name(@options[:name])
         return nil unless vm
@@ -1945,7 +1951,21 @@ _EOF_"
         bytes = vm.live2kvm_current_delta_size_bytes(@options[:work_dir])
         return nil if bytes.nil?
 
-        bytes.to_f / (1024 * 1024)
+        state = vm.live2kvm_state(@options[:work_dir]) || {}
+        measured_rate = state['base_transfer_mib_s'].to_f
+        if measured_rate > 0
+            source_rate = measured_rate
+            source_rate_source = 'measured prepare transfer'
+        else
+            source_rate = positive_float_option(:dry_run_source_export_mib_s)
+            source_rate_source = 'fallback'
+        end
+
+        {
+            :delta_mib => bytes.to_f / (1024 * 1024),
+            :source_rate => source_rate,
+            :source_rate_source => source_rate_source
+        }
     rescue StandardError => e
         @logger.warn "Unable to read prepared delta size: #{e.message}"
         nil

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -425,12 +425,14 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
     end
 
     def cleanup_passwords
-        puts 'Deleting password files.'
+        puts 'Deleting password files.' unless @options[:dry_run]
         File.delete("#{@options[:work_dir]}/vpassfile")
         File.delete("#{@options[:work_dir]}/esxpassfile")
     end
 
     def cleanup_disks
+        return if @options[:dry_run]
+
         if @options[:delete]
             puts "Deleting vdisks in #{"#{@options[:work_dir]}/conversions"}"
             FileUtils.rm_rf("#{@options[:work_dir]}/conversions")
@@ -443,6 +445,8 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
     end
 
     def cleanup_dirs
+        return if @options[:dry_run]
+
         if @options[:delete]
             puts "Deleting everything in and including #{"#{@options[:work_dir]}"}"
             FileUtils.rm_rf("#{@options[:work_dir]}")
@@ -1816,6 +1820,134 @@ _EOF_"
         create_one_images(disks_on_file)
     end
 
+    def run_dry_run_estimate
+        if @options[:delta]
+            return run_delta_dry_run_estimate
+        end
+
+        disks = dry_run_disk_metadata
+        total_provisioned_mib = disks.sum {|disk| disk[:provisioned_mib] }
+        total_data_mib = disks.sum {|disk| disk[:estimated_data_mib] }
+
+        source_rate = positive_float_option(:dry_run_source_export_mib_s)
+        convert_rate = positive_float_option(:dry_run_qcow2_conversion_mib_s)
+        import_rate = positive_float_option(:dry_run_target_import_mib_s)
+
+        export_time = total_data_mib / source_rate
+        conversion_time = total_data_mib / convert_rate
+        import_time = total_data_mib / import_rate
+
+        puts 'OneSwap dry-run estimate'
+        puts "VM: #{@options[:name]}"
+        puts "Disks: #{disks.length}"
+        disks.each_with_index do |disk, index|
+            puts "  disk #{index + 1}: provisioned #{format_mib(disk[:provisioned_mib])}, " \
+                 "estimated data #{format_mib(disk[:estimated_data_mib])} " \
+                 "(#{disk[:data_source]})"
+        end
+        puts "Total provisioned size: #{format_mib(total_provisioned_mib)}"
+        puts "Estimated data size: #{format_mib(total_data_mib)}"
+        puts
+        puts 'Throughput assumptions:'
+        puts "  source export: #{source_rate.round(2)} MiB/s"
+        puts "  qcow2 conversion: #{convert_rate.round(2)} MiB/s"
+        puts "  target import: #{import_rate.round(2)} MiB/s"
+        puts
+        puts 'Estimated phase durations:'
+        puts "  export: #{format_duration(export_time)}"
+        puts "  conversion: #{format_duration(conversion_time)}"
+        puts "  import: #{format_duration(import_time)}"
+        puts "  total: #{format_duration(export_time + conversion_time + import_time)}"
+        puts
+        puts 'Warning: configured fallback throughput values are used.'
+    end
+
+    def run_delta_dry_run_estimate
+        delta_mib = dry_run_known_delta_mib
+
+        puts 'OneSwap dry-run delta estimate'
+        puts "VM: #{@options[:name]}"
+
+        if delta_mib.nil?
+            puts 'Downtime estimate is not available. The remaining delta size is only known after the base phase has been completed.'
+            return
+        end
+
+        source_rate = positive_float_option(:dry_run_source_export_mib_s)
+        import_rate = positive_float_option(:dry_run_target_import_mib_s)
+        downtime = delta_mib / [source_rate, import_rate].min
+
+        puts "Known remaining delta size: #{format_mib(delta_mib)}"
+        puts "Bottleneck throughput: #{[source_rate, import_rate].min.round(2)} MiB/s"
+        puts "Estimated downtime: #{format_duration(downtime)}"
+    end
+
+    def dry_run_disk_metadata
+        devices = @props['config'][:hardware][:device]
+        devices.grep(RbVmomi::VIM::VirtualDisk).sort_by(&:key).map do |disk|
+            provisioned_mib = virtual_disk_provisioned_mib(disk)
+            allocated_mib = virtual_disk_allocated_mib(disk)
+
+            {
+                :provisioned_mib => provisioned_mib,
+                :estimated_data_mib => allocated_mib || provisioned_mib,
+                :data_source => allocated_mib ? 'allocated size from metadata' : 'provisioned size fallback'
+            }
+        end
+    end
+
+    def virtual_disk_provisioned_mib(disk)
+        if disk.respond_to?(:capacityInBytes) && disk.capacityInBytes
+            disk.capacityInBytes.to_f / (1024 * 1024)
+        else
+            disk.capacityInKB.to_f / 1024
+        end
+    end
+
+    def virtual_disk_allocated_mib(disk)
+        backing = disk.respond_to?(:backing) ? disk.backing : nil
+        return nil unless backing && backing.respond_to?(:committed) && backing.committed
+
+        backing.committed.to_f / (1024 * 1024)
+    end
+
+    def dry_run_known_delta_mib
+        # The current delta implementation runs the full flow inside live2kvm:
+        # snapshot creation, base transfer/conversion, VM shutdown, and delta apply.
+        # There is no persisted base-phase state or known remaining delta size yet.
+        nil
+    end
+
+    def positive_float_option(name)
+        value = @options[name].to_f
+        raise "#{name} must be greater than zero" if value <= 0
+
+        value
+    end
+
+    def format_mib(mib)
+        if mib >= 1024
+            "#{(mib / 1024).round(2)} GiB"
+        else
+            "#{mib.round(2)} MiB"
+        end
+    end
+
+    def format_duration(seconds)
+        seconds = seconds.round
+        hours = seconds / 3600
+        minutes = (seconds % 3600) / 60
+        secs = seconds % 60
+
+        if hours > 0
+            format('%dh %dm %ds', hours, minutes, secs)
+        elsif minutes > 0
+            format('%dm %ds', minutes, secs)
+        else
+            format('%ds', secs)
+        end
+    end
+
     # Create and run the qemu-img vmdk conversion
     # This uses qemu-img to convert an vmdk image to desired format (Default: qcow2).
     # Outputs a converted image location if success
@@ -3136,6 +3268,20 @@ GUESTFISH
         end
 
         @props = vm.to_hash
+
+        if @options[:dry_run]
+            if @props['config'][:guestFullName].include?('Windows') && @options[:custom_convert]
+                raise "Windows is not supported in OpenNebula's Custom Conversion process".red
+            end
+
+            # OpenNebula system prechecks
+            if !@options[:skip_prechecks]
+                one_prechecks(vm)
+            end
+
+            run_dry_run_estimate
+            return
+        end
 
         # If clone option is set, clone the VM and override VM properties
         if @options[:clone]

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1912,15 +1912,15 @@ _EOF_"
             return run_delta_dry_run_estimate
         end
 
+        run_source_export_benchmark if @options[:benchmark_export]
         run_opennebula_import_benchmark if @options[:benchmark_import]
 
         disks = dry_run_disk_metadata
         total_provisioned_mib = disks.sum {|disk| disk[:provisioned_mib] }
         total_data_mib = disks.sum {|disk| disk[:estimated_data_mib] }
 
-        source_rate = positive_float_option(:dry_run_source_export_mib_s)
-        source_rate_label = 'configured fallback, not measured'
-        source_basis = "configured fallback, not measured, #{source_rate.round(2)} MiB/s"
+        source_info = source_export_estimate
+        source_rate = source_info[:rate]
         convert_rate = positive_float_option(:dry_run_qcow2_conversion_mib_s)
         convert_rate_label = 'configured fallback, not measured'
         convert_basis = "configured fallback, not measured, #{convert_rate.round(2)} MiB/s"
@@ -1930,7 +1930,7 @@ _EOF_"
         export_time = total_data_mib / source_rate
         conversion_time = total_data_mib / convert_rate
         import_time = total_data_mib / import_rate
-        confidence = regular_dry_run_confidence(:configured_fallback,
+        confidence = regular_dry_run_confidence(source_info[:source],
                                                 :configured_fallback,
                                                 import_info[:source])
 
@@ -1947,12 +1947,12 @@ _EOF_"
         puts "Estimated data size: #{format_mib(total_data_mib)}"
         puts
         puts 'Estimate basis:'
-        puts "  source export: #{source_basis}"
+        puts "  source export: #{source_info[:basis]}"
         puts "  conversion: #{convert_basis}"
         puts "  target import: #{import_info[:basis]}"
         puts
         puts 'Rates:'
-        puts "  source export: #{source_rate.round(2)} MiB/s (#{source_rate_label})"
+        puts "  source export: #{source_rate.round(2)} MiB/s (#{source_info[:label]})"
         puts "  conversion: #{convert_rate.round(2)} MiB/s (#{convert_rate_label})"
         puts "  target import: #{import_rate.round(2)} MiB/s (#{import_info[:label]})"
         puts
@@ -2205,6 +2205,44 @@ _EOF_"
         value > 0 ? value : nil
     end
 
+    def source_export_estimate(metrics: read_metrics)
+        mode = dry_run_conversion_mode
+        previous_rate = metrics['source_export_mib_s'].to_f
+        previous_mode = metrics['source_export_mode']
+        if previous_rate > 0 && previous_mode == mode
+            label = "previous regular conversion: #{previous_rate.round(2)} MiB/s"
+            return {
+                :rate => previous_rate,
+                :source => :previous_metrics,
+                :label => label,
+                :basis => label
+            }
+        end
+
+        benchmark_rate = metrics['source_export_benchmark_mib_s'].to_f
+        benchmark_mode = metrics['source_export_benchmark_mode']
+        if benchmark_rate > 0 && benchmark_mode == mode
+            size_mib = metrics['source_export_benchmark_bytes'].to_i.to_f / (1024 * 1024)
+            seconds = metrics['source_export_benchmark_seconds'].to_f
+            label = source_export_benchmark_label(size_mib, seconds)
+            return {
+                :rate => benchmark_rate,
+                :source => :benchmark,
+                :label => label,
+                :basis => "#{label}, #{benchmark_rate.round(2)} MiB/s"
+            }
+        end
+
+        rate = positive_float_option(:dry_run_source_export_mib_s)
+        label = 'configured fallback, not measured'
+        {
+            :rate => rate,
+            :source => :configured_fallback,
+            :label => label,
+            :basis => "#{label}, #{rate.round(2)} MiB/s"
+        }
+    end
+
     def target_import_estimate(metrics: read_metrics, prefer_previous_full: true)
         import_mode = opennebula_import_mode
         measured_import_rate = metrics['opennebula_import_mib_s'].to_f
@@ -2260,12 +2298,12 @@ _EOF_"
     end
 
     def regular_dry_run_confidence(source_rate_source, convert_rate_source, import_rate_source)
-        source_measured = source_rate_source == :previous_metrics
+        source_measured = [:previous_metrics, :benchmark].include?(source_rate_source)
         convert_measured = convert_rate_source == :previous_metrics
         import_measured = [:previous_full_import, :large_benchmark, :small_benchmark].include?(import_rate_source)
 
         return 'high' if source_measured && convert_measured && import_measured
-        return 'medium' if import_measured
+        return 'medium' if [source_measured, convert_measured, import_measured].any?
 
         'low'
     end
@@ -2311,6 +2349,16 @@ _EOF_"
                     "measured benchmark: #{format_mib(size_mib)}"
                 else
                     "measured benchmark: #{rate.round(2)} MiB/s"
+                end
+        label += " in #{format_duration(seconds)}" if seconds > 0
+        label
+    end
+
+    def source_export_benchmark_label(size_mib, seconds)
+        label = if size_mib > 0
+                    "measured VMware datastore download benchmark: #{format_mib(size_mib)}"
+                else
+                    'measured VMware datastore download benchmark'
                 end
         label += " in #{format_duration(seconds)}" if seconds > 0
         label
@@ -2459,6 +2507,78 @@ _EOF_"
             end
             FileUtils.rm_f(test_file)
         end
+    end
+
+    def run_source_export_benchmark
+        datastore_info = source_benchmark_datastore
+        unless datastore_info
+            puts 'Warning: source export benchmark skipped because no VM source datastore was found.'
+            puts 'The dry-run estimate will use previous matching source metrics or dry_run_source_export_mib_s.'
+            return
+        end
+
+        size_mib = positive_float_option(:dry_run_source_benchmark_size_mib).to_i
+        remote_file = ".oneswap-source-benchmark-#{safe_benchmark_name(@options[:name])}-#{Time.now.to_i}.bin"
+        remote_path = "#{ESXi::Client::DATASTORES_PATH}/#{datastore_info[:name]}/#{remote_file}"
+        local_dir = File.join(@options[:work_dir], 'dry-run-source-benchmark')
+        FileUtils.mkdir_p(local_dir)
+        local_file = File.join(local_dir, remote_file)
+        esxi_client = nil
+
+        puts "Running source export benchmark for #{dry_run_conversion_mode} with #{format_mib(size_mib.to_f)} VMware datastore file."
+        begin
+            esxi_client = ESXi::Client.new(get_esxi_host, @logger, esxi_client_options(:non_interactive => true))
+            unless esxi_client.create_zero_file(remote_path, size_mib)
+                raise "unable to create temporary benchmark file on datastore #{datastore_info[:name]}"
+            end
+
+            t0 = Time.now
+            datastore_info[:object].download(remote_file, local_file)
+            seconds = Time.now - t0
+            bytes = File.exist?(local_file) ? File.size(local_file) : 0
+            mib_s = mib_per_second(bytes, seconds)
+            raise 'source export benchmark downloaded no data' unless mib_s
+
+            write_metrics({
+                              'source_export_benchmark_bytes' => bytes,
+                              'source_export_benchmark_seconds' => seconds,
+                              'source_export_benchmark_mib_s' => mib_s,
+                              'source_export_benchmark_mode' => dry_run_conversion_mode,
+                              'source_export_benchmark_at' => Time.now.utc.iso8601,
+                              'source_export_benchmark_datastore' => datastore_info[:name]
+                          })
+
+            puts "Source export benchmark: #{format_mib(bytes.to_f / (1024 * 1024))} in " \
+                 "#{format_duration(seconds)} (#{mib_s.round(2)} MiB/s)"
+        rescue StandardError => e
+            puts "Warning: source export benchmark failed: #{e.message}"
+            puts 'The dry-run estimate will use previous matching source metrics or dry_run_source_export_mib_s.'
+        ensure
+            FileUtils.rm_f(local_file)
+            begin
+                esxi_client.remove_files(remote_path) if esxi_client
+            rescue StandardError => e
+                @logger.warn "Unable to remove source benchmark file #{remote_path}: #{e.message}"
+            end
+        end
+    end
+
+    def source_benchmark_datastore
+        disk = @props['config'][:hardware][:device].grep(RbVmomi::VIM::VirtualDisk).sort_by(&:key).first
+        return nil unless disk && disk.respond_to?(:backing)
+
+        datastore_name = disk.backing.fileName.to_s[/^\[(.+?)\]/, 1]
+        datastore_obj = disk.backing.respond_to?(:datastore) ? disk.backing.datastore : nil
+        return nil unless datastore_name && datastore_obj
+
+        {
+            :name => datastore_name,
+            :object => datastore_obj
+        }
+    end
+
+    def safe_benchmark_name(name)
+        name.to_s.gsub(/[^A-Za-z0-9_.-]/, '_')
     end
 
     def start_http_transfer_server(document_root)


### PR DESCRIPTION
### Description

This PR improves OneSwap dry-run estimation for regular and staged delta migrations.

This is a feature PR and is best reviewed commit-by-commit.

Main changes:
- Add regular dry-run estimates for source export, conversion, OpenNebula import, and total time.
- Add optional import benchmark support with temporary OpenNebula image cleanup.
- Add optional source export benchmark support for regular dry-run estimates.
- Add staged delta workflow with prepare, estimate, commit, and cleanup phases.
- Reuse measured delta prepare metrics for delta transfer/apply estimates.
- Refresh current delta size from the ESXi snapshot extent.
- Improve HTTP transfer handling for remote OneSwap workers.
- Add guard for unsafe local-path imports from remote workers.
- Improve delta cleanup, including conservative missing-state cleanup for OneSwap-created snapshots.
- Avoid reusing real HTTP import timings as trusted metrics; HTTP estimates use benchmark metrics or configured fallback.


### Branches to which this PR applies

- [x] master
