### PR TITLE
F #7788: Add vSAN VDDK guard for OneSwap conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ and copies only the VDDK plugin into nbdkit's plugin directory. It requires
 internet access, or an internal mirror via the `NBDKIT_REPO_URL` environment
 variable.
 
+VDDK mode is also required for VMware vSAN-backed VMDKs. vSAN disks are
+object-backed and are not available through the classic vCenter datastore
+`*-flat.vmdk` download path used by the non-VDDK and hybrid transfer modes.
+
+To convert VMs stored on a vSAN datastore, configure VDDK:
+
+```yaml
+:vddk_path: '/opt/vmware-vix-disklib-distrib/'
+```
+
 ## Dry-run Estimates
 
 OneSwap can estimate migration time without running the full conversion. Dry-run

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -138,6 +138,15 @@ end
 class ConversionError < StandardError; end
 
 class OneSwapHelper < OpenNebulaHelper::OneHelper
+    VSAN_VDDK_REQUIRED_MESSAGE = 'vSAN-backed VMDK conversion requires VDDK. ' \
+                                 'Please configure :vddk_path in the OneSwap config file ' \
+                                 'or pass --vddk /path/to/vmware-vix-disklib-distrib/.'
+    VSAN_DELTA_UNSUPPORTED_MESSAGE = 'Delta mode is not currently supported for vSAN-backed disks. ' \
+                                     'Please use full conversion with VDDK.'
+    VSAN_HYBRID_UNSUPPORTED_MESSAGE = 'Hybrid mode is not currently supported for vSAN-backed disks ' \
+                                      'because it uses vCenter datastore VMDK downloads. ' \
+                                      'Please use full conversion with VDDK.'
+
     include WindowsTuner
 
     ONE_LOGS = '/var/log/one'
@@ -1547,6 +1556,34 @@ _EOF_"
                   ' --root first'\
                   " -os #{@options[:work_dir]}/conversions/"\
                   " -of #{@options[:format]}"
+    end
+
+    def vc_virtual_disks
+        @props['config'][:hardware][:device].grep(RbVmomi::VIM::VirtualDisk)
+    end
+
+    def vsan_backed_disks
+        vc_virtual_disks.select {|disk| vsan_backed_disk?(disk) }
+    end
+
+    def vsan_backed_disk?(disk)
+        backing = disk.backing
+        datastore = backing.respond_to?(:datastore) ? backing.datastore : nil
+        type = datastore&.summary&.type.to_s.downcase
+        return true if type == 'vsan'
+
+        datastore_name = backing.fileName.to_s[/^\[(.+?)\]/, 1]
+        datastore_name.to_s.downcase == 'vsandatastore'
+    rescue StandardError
+        false
+    end
+
+    def validate_vsan_conversion!
+        return if vsan_backed_disks.empty?
+
+        raise VSAN_DELTA_UNSUPPORTED_MESSAGE.red if @options[:delta]
+        raise VSAN_HYBRID_UNSUPPORTED_MESSAGE.red if @options[:hybrid]
+        raise VSAN_VDDK_REQUIRED_MESSAGE.red unless @options[:vddk_path]
     end
 
     def build_v2v_vc_cmd
@@ -4052,6 +4089,7 @@ GUESTFISH
         end
 
         @props = vm.to_hash
+        validate_vsan_conversion!
 
         if @options[:dry_run]
             if @props['config'][:guestFullName].include?('Windows') && @options[:custom_convert]


### PR DESCRIPTION
### Description

Adds an early guard for vSAN-backed source disks in OneSwap.

Lab testing showed that the non-VDDK conversion path fails for VMs stored on `vsanDatastore` because it tries to access a classic `*-flat.vmdk` through the vCenter datastore URL. vSAN disks are object-backed, so this path returns `URL not found`.

The same VM converts successfully when VDDK is enabled.

## Behavior

- vSAN + no VDDK: fail early with a clear actionable error
- vSAN + VDDK: continue normally
- vSAN + `--delta`: fail early as unsupported
- vSAN + `--hybrid`: fail early as unsupported because it uses vCenter datastore VMDK downloads

### Branches to which this PR applies

- [x] master
