### PR TITLE
F #7336: Add libguestfs appliance path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ The following packages must be installed on the conversion host:
 
 When installing OneSwap via the provided packages all dependencies are installed automatically. If deploying from source, the dependencies listed in the table above must be installed manually using the system package manager.
 
+### Non-root libguestfs
+
+When OneSwap is executed as a non-root user, libguestfs/supermin may fail if
+the user cannot read the host kernel image under `/boot/vmlinuz-*`. In that
+case, configure a prebuilt libguestfs appliance with `:libguestfs_path:` or
+pass `--libguestfs-path`.
+
+Detailed setup steps are documented in the OpenNebula documentation.
+
 ## Windows CompactOS Support
 
 Windows guests that use NTFS system compression (CompactOS / WOF) fail

--- a/oneswap
+++ b/oneswap
@@ -511,6 +511,13 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    LIBGUESTFS_PATH = {
+        :name => 'libguestfs_path',
+        :large => '--libguestfs-path /path/to/libguestfs-appliance',
+        :description => 'Path to prebuilt libguestfs appliance for non-root execution',
+        :format => String
+    }
+
     HTTP_TRANSFER = {
         :name => 'http_transfer',
         :large => '--http-transfer',
@@ -635,7 +642,7 @@ CommandParser::CmdParser.new(ARGV) do
     }
 
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
-    V2V_OPTS = [V2V_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
+    V2V_OPTS = [V2V_PATH, LIBGUESTFS_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT, ALLOW_LOCAL_PATH_REMOTE]
 
     LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -58,6 +58,7 @@
 #:virtio_path:                            # Path to VirtIO drivers for Windows
 #:virt_tools: /usr/local/share/virt-tools # Path to the directory containing rhsrvany.exe
 #:v2v_path: 'virt-v2v'                    # Path to virt-v2v
+#:libguestfs_path: /var/lib/one/libguestfs-appliance # Path to prebuilt libguestfs appliance for non-root execution
 #:root: 'first'                           # Choose the root filesystem to be converted
 
 # Extra Options

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1762,6 +1762,25 @@ _EOF_"
                   " --root=#{@options[:root]}"
     end
 
+    def v2v_env
+        libguestfs_path = @options[:libguestfs_path].to_s.strip
+        return {} if libguestfs_path.empty?
+
+        { 'LIBGUESTFS_PATH' => libguestfs_path }
+    end
+
+    def warn_unreadable_kernel_for_libguestfs(env)
+        return if Process.uid == 0 || env.key?('LIBGUESTFS_PATH')
+
+        kernel = "/boot/vmlinuz-#{`uname -r`.strip}"
+        return if File.readable?(kernel)
+
+        STDERR.puts "Warning: #{kernel} is not readable by the current user. "\
+                    'libguestfs/supermin may fail while building its appliance. '\
+                    'Configure :libguestfs_path: to use a prebuilt libguestfs appliance, '\
+                    'or run OneSwap as root.'
+    end
+
     # Create and run the virt-v2v conversion
     # This uses virt-v2v to connect to vCenter/ESXi, create an overlay on the remote disk,
     #   and convert it before using qemu-img convert over nbdkit connection.  Outputs a
@@ -1785,10 +1804,12 @@ _EOF_"
         end
 
         puts "Running: #{command}"
+        env = v2v_env
+        warn_unreadable_kernel_for_libguestfs(env)
 
         begin
             error_check = nil
-            _stdin, stdout, stderr, wait_thr = Open3.popen3(command)
+            _stdin, stdout, stderr, wait_thr = Open3.popen3(env, command)
 
             # Handle each std pipe as a separate thread
             stdout_thread = Thread.new do


### PR DESCRIPTION
### Description

This adds minimal support for configuring a prebuilt libguestfs appliance path for OneSwap.

When `:libguestfs_path:` is configured, or `--libguestfs-path` is passed, OneSwap sets `LIBGUESTFS_PATH` only for the `virt-v2v` execution environment. This allows non-root users to avoid `libguestfs/supermin` depending on read access to the host kernel image under `/boot/vmlinuz-*`.

The patch also adds a warning for non-root executions when no `libguestfs_path` is configured and the current kernel image is not readable by the current user.

## Changes

* Added `:libguestfs_path:` configuration option.
* Added `--libguestfs-path` CLI option.
* Passed `LIBGUESTFS_PATH` only to the `virt-v2v` execution environment.
* Added a warning when running as non-root without `libguestfs_path` and `/boot/vmlinuz-$(uname -r)` is not readable.
* Added a short README note. Detailed setup steps will be documented in one-docs.

## Validation

Tested on Ubuntu 24.04 running OneSwap as `oneadmin`.

The active kernel image was not readable by the unprivileged user:

```text
-rw------- 1 root root /boot/vmlinuz-6.8.0-134-generic
```

Without `:libguestfs_path:` configured, OneSwap prints the expected warning:

```text
Warning: /boot/vmlinuz-6.8.0-134-generic is not readable by the current user. libguestfs/supermin may fail while building its appliance. Configure :libguestfs_path: to use a prebuilt libguestfs appliance, or run OneSwap as root.
```

The conversion then fails in `supermin`, reproducing the original issue:

```text
cp: cannot open '/boot/vmlinuz-6.8.0-134-generic' for reading: Permission denied
libguestfs: error: /usr/bin/supermin exited with error status 1
```

After configuring a prebuilt libguestfs appliance with:

```yaml
:libguestfs_path: /var/lib/one/libguestfs-appliance
```

the warning is no longer printed and the conversion proceeds past the libguestfs/supermin stage.

### Branches to which this PR applies

- [x] master

