### PR TITLE
F #7343: Warn about missing VirtIO drivers for Windows guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ appliance rebuild includes it automatically (no fixed appliance or
 `LIBGUESTFS_PATH` needed). It requires internet access, or an internal mirror
 via the `NTFS_WOF_REPO_URL` environment variable.
 
+Windows guests using the `vd` device prefix require VirtIO block drivers to
+boot. OneSwap warns before conversion when no `virtio_path` is configured for
+that case; configure it in `oneswap.yaml` or pass the existing VirtIO CLI option.
+
 ## VDDK Transfer Support
 
 `--vddk` transfers require the nbdkit VDDK plugin, which Debian/Ubuntu

--- a/oneswap
+++ b/oneswap
@@ -780,7 +780,7 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])
                 raise 'Cannot use Hybrid option with Custom, ESXi, or VDDK options.'
             end
-            if options[:virtio_path] && !File.exist?(options[:virtio_path])
+            if options[:virtio_path] && !options[:virtio_path].to_s.strip.empty? && !File.exist?(options[:virtio_path])
                 raise "Windows VirtIO ISO cannot be found at #{options[:virtio_path]}"
             end
             if options[:qemu_ga_win] && !File.exist?(options[:qemu_ga_win])
@@ -895,7 +895,7 @@ CommandParser::CmdParser.new(ARGV) do
             if options[:hybrid] && (options[:custom_convert] || options[:esxi_ip] || options[:vddk_path])
                 raise 'Cannot use Hybrid option with Custom, ESXi, or VDDK options.'
             end
-            if options[:virtio_path] && !File.exist?(options[:virtio_path])
+            if options[:virtio_path] && !options[:virtio_path].to_s.strip.empty? && !File.exist?(options[:virtio_path])
                 raise "Windows VirtIO ISO cannot be found at #{options[:virtio_path]}"
             end
             if options[:qemu_ga_win] && !File.exist?(options[:qemu_ga_win])

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -3633,6 +3633,30 @@ GUESTFISH
         raise(msg.red)
     end
 
+    def effective_dev_prefix(os_name)
+        if @options[:dev_prefix]
+            @options[:dev_prefix].to_s
+        elsif os_name == 'windows'
+            'vd'
+        end
+    end
+
+    def virtio_path_configured?
+        return false unless @options[:virtio_path]
+
+        !@options[:virtio_path].to_s.strip.empty?
+    end
+
+    def warn_if_windows_virtio_iso_missing(os_name)
+        return false unless os_name == 'windows'
+        return false unless effective_dev_prefix(os_name) == 'vd'
+        return false if virtio_path_configured?
+
+        puts 'Warning: Windows guest will use VirtIO block devices, but no VirtIO driver ISO is configured.'.brown
+        puts 'The converted VM may fail to boot. Configure virtio_path in oneswap.yaml or provide the existing VirtIO CLI option.'.brown
+        true
+    end
+
     # Run a OpenNebula system prechecks:
     #
     # - Check if there is enough space in the datastore
@@ -3645,6 +3669,7 @@ GUESTFISH
         config = @props.to_h['config']
         if config && config[:guestFullName].to_s.include?('Windows')
             warn_if_wof_support_missing
+            warn_if_windows_virtio_iso_missing('windows')
         end
         check_nbdkit_vddk_plugin! if @options[:vddk_path]
         ## Precheck datastore space (check if it will be enough space for the image)
@@ -4029,12 +4054,9 @@ GUESTFISH
 
         img_ids.each do |i|
             img_hash = { 'IMAGE_ID' => "#{i[:id]}" }
-            if @options[:dev_prefix]
-                img_hash['DEV_PREFIX'] = "#{@options[:dev_prefix]}"
-            elsif i[:os]
-                if i[:os] == 'windows'
-                    img_hash['DEV_PREFIX'] = 'vd'
-                end
+            dev_prefix = effective_dev_prefix(i[:os])
+            unless dev_prefix.nil?
+                img_hash['DEV_PREFIX'] = dev_prefix
             end
             vm_template.add_element('//VMTEMPLATE', { 'DISK' => img_hash })
         end
@@ -4185,12 +4207,9 @@ GUESTFISH
 
         img_ids.each do |i|
             img_hash = { 'IMAGE_ID' => "#{i[:id]}" }
-            if @options[:dev_prefix]
-                img_hash['DEV_PREFIX'] = "#{@options[:dev_prefix]}"
-            elsif i[:os]
-                if i[:os] == 'windows'
-                    img_hash['DEV_PREFIX'] = 'vd'
-                end
+            dev_prefix = effective_dev_prefix(i[:os])
+            unless dev_prefix.nil?
+                img_hash['DEV_PREFIX'] = dev_prefix
             end
             vm_template.add_element('//VMTEMPLATE', { 'DISK' => img_hash })
         end

--- a/tests/dry_run_safety_test.rb
+++ b/tests/dry_run_safety_test.rb
@@ -113,4 +113,58 @@ class DryRunSafetyTest < Minitest::Test
 
         assert_nil h.send(:local_path_image_allocation_preflight!)
     end
+
+    def test_windows_vd_without_virtio_path_warns_and_continues
+        h = helper
+
+        out, = capture_io do
+            assert h.send(:warn_if_windows_virtio_iso_missing, 'windows')
+        end
+
+        assert_includes out, 'Windows guest will use VirtIO block devices'
+        assert_includes out, 'no VirtIO driver ISO is configured'
+        assert_includes out, 'may fail to boot'
+        assert_includes out, 'virtio_path in oneswap.yaml'
+    end
+
+    def test_windows_vd_with_valid_virtio_path_does_not_warn
+        h = helper(:virtio_path => __FILE__)
+
+        out, = capture_io do
+            refute h.send(:warn_if_windows_virtio_iso_missing, 'windows')
+        end
+
+        refute_includes out, 'no VirtIO driver ISO is configured'
+    end
+
+    def test_windows_non_vd_device_prefix_does_not_warn
+        h = helper(:dev_prefix => 'sd')
+
+        out, = capture_io do
+            refute h.send(:warn_if_windows_virtio_iso_missing, 'windows')
+        end
+
+        refute_includes out, 'no VirtIO driver ISO is configured'
+    end
+
+    def test_non_windows_vd_does_not_warn
+        h = helper(:dev_prefix => 'vd')
+
+        out, = capture_io do
+            refute h.send(:warn_if_windows_virtio_iso_missing, 'linux')
+        end
+
+        refute_includes out, 'no VirtIO driver ISO is configured'
+    end
+
+    def test_nonempty_virtio_path_suppresses_missing_configuration_warning
+        h = helper(:virtio_path => '/nonexistent/virtio-win.iso')
+
+        out, = capture_io do
+            refute h.send(:warn_if_windows_virtio_iso_missing, 'windows')
+        end
+
+        assert h.send(:virtio_path_configured?)
+        refute_includes out, 'no VirtIO driver ISO is configured'
+    end
 end


### PR DESCRIPTION
### Description

OneSwap already supports injecting Windows VirtIO drivers through the existing
`virtio_path` option. However, when a Windows guest is converted using the `vd`
device prefix without configuring a VirtIO ISO, the resulting VM may fail to
boot.

This change adds a pre-conversion warning when:

- the source guest is detected as Windows;
- the effective disk device prefix is `vd`;
- no `virtio_path` is configured.

The warning is informational only and does not block the conversion.

The existing behavior for a configured but nonexistent VirtIO ISO remains
unchanged.

### Branches to which this PR applies

- [x] master

