### PR TITLE
F #7334: Propagate OpenNebula allocation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ OneSwap is a command-line tool designed to simplify converting Virtual Machines 
 
 OneSwap has been used in the field with a 96% success rate in converting VMs automatically, greatly simplifying and speeding up the migration process.
 
+When OpenNebula Image or VM Template allocation fails, OneSwap reports the
+OpenNebula API error directly and stops the current conversion.
+
 The full documentation is available in the in the [OpenNebula documentation](https://docs.opennebula.io/stable/):
 
   - For guide on converting Virtual Machines from vCenter to OpenNebula, see [Migrating VMs with OneSwap](https://docs.opennebula.io/stable/software/migration_from_vmware/oneswap/)

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -2988,8 +2988,9 @@ _EOF_"
                 path = d
             end
 
+            img_name = "#{@options[:name]}_#{i}"
             img.add_element('//IMAGE', {
-                                'NAME' => "#{@options[:name]}_#{i}",
+                                'NAME' => img_name,
                 'TYPE' => guest_info ? 'OS' : 'DATABLOCK',
                 'PATH' => path,
                 'PERSISTENT' => persistent_image
@@ -3002,11 +3003,8 @@ _EOF_"
             import_t0 = Time.now
             rc = img.allocate(img.to_xml, ds_id)
 
-            if rc.class == OpenNebula::Error
-                puts 'Failed to create image. Image Definition:'.red
-                puts img.to_xml
-                puts "OpenNebula error: #{rc.message}".red
-                next
+            if OpenNebula.is_error?(rc)
+                raise "Failed to create OpenNebula image '#{img_name}':\n#{rc.message}"
             end
 
             chown_one_object(img, *resolve_one_ownership)
@@ -4070,14 +4068,13 @@ GUESTFISH
 
         rc = vm_template.allocate(vm_template.to_xml)
 
-        if rc.nil?
-            puts 'Success'.green
-            puts "VM Template ID: #{vm_template.id}\n"
-            chown_one_object(vm_template, *resolve_one_ownership)
-        else
-            puts 'Failed'.red
-            puts "\nVM Template:\n#{vm_template.to_xml}\n"
+        if OpenNebula.is_error?(rc)
+            raise "Failed to create OpenNebula VM template '#{@options[:name]}':\n#{rc.message}"
         end
+
+        puts 'Success'.green
+        puts "VM Template ID: #{vm_template.id}\n"
+        chown_one_object(vm_template, *resolve_one_ownership)
     end
 
     # Import Image
@@ -4246,14 +4243,13 @@ GUESTFISH
 
         rc = vm_template.allocate(vm_template.to_xml)
 
-        if rc.nil?
-            puts 'Success'.green
-            puts "VM Template ID: #{vm_template.id}\n"
-            chown_one_object(vm_template, *resolve_one_ownership)
-        else
-            puts 'Failed'.red
-            puts "\nVM Template:\n#{vm_template.to_xml}\n"
+        if OpenNebula.is_error?(rc)
+            raise "Failed to create OpenNebula VM template '#{@options[:name]}':\n#{rc.message}"
         end
+
+        puts 'Success'.green
+        puts "VM Template ID: #{vm_template.id}\n"
+        chown_one_object(vm_template, *resolve_one_ownership)
 
         set_sunstone_labels(tags, vm_template.id) unless tags.empty?
     end


### PR DESCRIPTION
### Description

OpenNebula Image and VM Template allocation failures were previously reported with a generic message, while OneSwap continued processing.

For Image allocation failures, this could lead to readiness polling with no valid Image ID, processing additional disks, and attempting to create a VM Template with invalid Image references. The actual failure reason was only visible in `oned.log`.

This change makes OneSwap fail fast when OpenNebula allocation fails.

## Changes

- Report the full OpenNebula API error when Image allocation fails.
- Stop the current conversion immediately after an Image allocation failure.
- Do not continue Image readiness polling or process remaining disks after a failed allocation.
- Report the full OpenNebula API error when VM Template allocation fails.
- Stop immediately instead of continuing after a failed VM Template allocation.
- Preserve the existing successful allocation and cleanup behavior.
- Add a short README note describing the new behavior.

No retry logic or new configuration options are introduced.

After disk conversion and customization, Image allocation failed with:

```
Failed. Fallback is not enabled. Raising error.
Error: Failed to create OpenNebula image 'oneswap-src-ubuntu-01_0':
[one.image.allocate] Error getting datastore [999999].
```

### Branches to which this PR applies

- [x] master
