### PR TITLE
M  #839: Sync OneSwap supported guest OS mappings

### DIFF
--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1042,6 +1042,8 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
         distro_info['distro']  = disk_xml["#{xprefix}/distro"].text
         distro_info['name']    = disk_xml["#{xprefix}/name"].text
         distro_info['os']      = disk_xml["#{xprefix}/osinfo"].text
+        major_version = disk_xml["#{xprefix}/major_version"]
+        distro_info['major_version'] = major_version.text if major_version
         if distro_info['distro'] != 'windows'
             distro_info['pkg'] = disk_xml["#{xprefix}/package_format"].text
         end
@@ -1061,6 +1063,8 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
             c_files = Dir.glob("#{@options[:context]}/one-context*el8*rpm")
         when 'rhel9'
             c_files = Dir.glob("#{@options[:context]}/one-context*el9*rpm")
+        when 'rhel10'
+            c_files = Dir.glob("#{@options[:context]}/one-context*el10*rpm")
         when 'fedora'
             c_files = Dir.glob("#{@options[:context]}/one-context*fc*rpm")
         when 'debian'
@@ -1141,12 +1145,19 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
         end
 
         # os gives versions, so check that instead of distro
-        if osinfo['os'] =~ /^(redhat-based|rhel|fedora|ubuntu|debian)/ # start_with any of these
+        guest_os = osinfo['os'].to_s
+        if ['', 'unknown', 'redhat-based'].include?(guest_os) &&
+           osinfo['distro'] == 'redhat-based' &&
+           osinfo['major_version'].to_s == '10'
+            guest_os = 'rhel10'
+        end
+
+        if guest_os =~ /^(redhat-based|rhel|fedora|ubuntu|debian|almalinux(8|9|10)|rocky(8|9|10)|ol(8|9|10)|centos-stream[89])/ # start_with any of these
             os = nil
             opts = []
             fallback_opts = []
 
-            case osinfo['os']
+            case guest_os
             when /^fedora/
                 os = 'fedora'
                 opts = [
@@ -1164,7 +1175,7 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                     " --run-command 'systemctl disable systemd-networkd-wait-online'",
                     " --run-command 'sed -i \"s/SELINUX=enforcing/SELINUX=disabled/\" /etc/selinux/config || exit 0'"
                 ]
-            when /^redhat-based8/, /^rhel8/
+            when /^redhat-based8/, /^rhel8/, /^almalinux8/, /^rocky8/, /^ol8/, /^centos-stream8/
                 os = 'rhel8'
                 opts = [
                     " --run-command 'subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms'",
@@ -1180,7 +1191,7 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                     ' --firstboot-install /tmp/%<basename>s',
                     " --run-command 'systemctl enable NetworkManager.service || exit 0'"
                 ]
-            when /^redhat-based9/, /^rhel9/
+            when /^redhat-based9/, /^rhel9/, /^almalinux9/, /^rocky9/, /^ol9/, /^centos-stream9/
                 os = 'rhel9'
                 opts = [
                     " --run-command 'subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms'",
@@ -1192,6 +1203,19 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                 ]
                 fallback_opts = [
                     ' --firstboot-install epel-release',
+                    ' --copy-in %<context>s:/tmp',
+                    ' --firstboot-install /tmp/%<basename>s',
+                    " --run-command 'systemctl enable NetworkManager.service || exit 0'"
+                ]
+            when /^redhat-based10(?:\.|$)/, /^rhel10/, /^almalinux10/, /^rocky10/, /^ol10/
+                os = 'rhel10'
+                opts = [
+                    ' --copy-in %<context>s:/tmp',
+                    ' --install /tmp/%<basename>s',
+                    ' --delete /tmp/%<basename>s',
+                    " --run-command 'systemctl enable NetworkManager.service || exit 0'"
+                ]
+                fallback_opts = [
                     ' --copy-in %<context>s:/tmp',
                     ' --firstboot-install /tmp/%<basename>s',
                     " --run-command 'systemctl enable NetworkManager.service || exit 0'"
@@ -1213,6 +1237,8 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                 ]
             end
 
+            return false unless os
+
             context_fullpath = detect_context_package(os)
             return false unless context_fullpath
 
@@ -1225,8 +1251,8 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
             cmd = base_cmd + opts.map {|c| c % vars }.join
             fallback_cmd = base_cmd + fallback_opts.map {|c| c % vars }.join
 
-        elsif osinfo['os'].start_with?('alt', 'opensuse', 'sles')
-            os = osinfo['os'].start_with?('alt') ? 'alt' : 'opensuse'
+        elsif guest_os.start_with?('alt', 'opensuse', 'sles', 'sled')
+            os = guest_os.start_with?('alt') ? 'alt' : 'opensuse'
             context_fullpath = detect_context_package(os)
             return false unless context_fullpath
 
@@ -1239,7 +1265,7 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                             " --copy-in #{context_fullpath}:/tmp"\
                             " --firstboot-install /tmp/#{context_basename}"
 
-        elsif osinfo['os'].start_with?('freebsd')
+        elsif guest_os.start_with?('freebsd')
             # may not mount properly sometimes due to internal fs
             context_fullpath = detect_context_package('freebsd')
             return false unless context_fullpath
@@ -1255,7 +1281,7 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
                             " --copy-in #{context_fullpath}:/tmp"\
                             " --firstboot-install /tmp/#{context_basename}"
 
-        elsif osinfo['os'].start_with?('alpine')
+        elsif guest_os.start_with?('alpine')
             puts 'Alpine is not compatible with offline install, please install context manually.'.brown
             return false
         end

--- a/tests/context_command_os_mapping_test.rb
+++ b/tests/context_command_os_mapping_test.rb
@@ -1,0 +1,205 @@
+# Unit-style checks for context package family selection.
+# Run with: ruby tests/context_command_os_mapping_test.rb
+
+require 'logger'
+require 'minitest/autorun'
+require 'ostruct'
+require 'rexml/document'
+require 'tmpdir'
+
+module OpenNebulaHelper
+    class OneHelper; end
+end
+
+module Kernel
+    alias oneswap_context_mapping_original_require require
+
+    def require(path)
+        return true if ['one_helper', 'opennebula'].include?(path)
+
+        oneswap_context_mapping_original_require(path)
+    end
+end
+
+require_relative '../oneswap_helper'
+
+class ContextCommandOsMappingTest < Minitest::Test
+    def helper
+        OneSwapHelper.allocate.tap do |h|
+            h.instance_variable_set(:@options, {
+                :inject_dns => false
+            })
+            h.instance_variable_set(:@logger, Logger.new(File::NULL))
+        end
+    end
+
+    def assert_context_family(osinfo_id, expected_family, message = nil)
+        assert_context_family_for({
+            'name' => 'linux',
+            'os' => osinfo_id
+        }, expected_family, message)
+    end
+
+    def assert_context_family_for(osinfo, expected_family, message = nil)
+        h = helper
+        detected = []
+        h.define_singleton_method(:detect_context_package) do |family|
+            detected << family
+            "/tmp/one-context-#{family}.pkg"
+        end
+
+        cmd, fallback_cmd = h.send(:context_command, '/tmp/disk.qcow2', osinfo)
+
+        assert_equal [expected_family], detected, message
+        assert_includes cmd, "/tmp/one-context-#{expected_family}.pkg", message
+        assert_includes fallback_cmd, "/tmp/one-context-#{expected_family}.pkg", message
+    end
+
+    def test_direct_mappings
+        cases = [
+            ['almalinux8', 'rhel8'],
+            ['rocky8', 'rhel8'],
+            ['ol8.8', 'rhel8'],
+            ['centos-stream8', 'rhel8'],
+            ['almalinux9', 'rhel9'],
+            ['rocky9', 'rhel9'],
+            ['ol9.4', 'rhel9'],
+            ['centos-stream9', 'rhel9'],
+            ['rhel10', 'rhel10'],
+            ['almalinux10', 'rhel10'],
+            ['rocky10', 'rhel10'],
+            ['ol10', 'rhel10'],
+            ['redhat-based10', 'rhel10'],
+            ['redhat-based10.2', 'rhel10'],
+            ['debian12', 'debian'],
+            ['ubuntu24.04', 'debian'],
+            ['ubuntu26.04', 'debian'],
+            ['rhel8.10', 'rhel8'],
+            ['rhel9.4', 'rhel9'],
+            ['opensuse15.6', 'opensuse'],
+            ['sles15.6', 'opensuse'],
+            ['sled12', 'opensuse']
+        ]
+
+        cases.each do |osinfo_id, expected_family|
+            msg = "#{osinfo_id.inspect} should map to #{expected_family.inspect}"
+            assert_context_family(osinfo_id, expected_family, msg)
+        end
+    end
+
+    def test_el10_fallback_mappings
+        [nil, '', 'unknown', 'redhat-based'].each do |osinfo_id|
+            osinfo = {
+                'name' => 'linux', 'os' => osinfo_id, 'distro' => 'redhat-based',
+                'major_version' => '10'
+            }
+
+            assert_context_family_for(osinfo, 'rhel10', "#{osinfo.inspect} should map to \"rhel10\"")
+        end
+    end
+
+    def test_unknown_os_returns_false_without_package_lookup
+        h = helper
+        h.define_singleton_method(:detect_context_package) do |family|
+            raise "unexpected package lookup for #{family}"
+        end
+
+        assert_equal false, h.send(:context_command, '/tmp/disk.qcow2', {
+            'name' => 'linux',
+            'os' => 'unknownos1'
+        })
+    end
+
+    def test_unsupported_cases_return_false_without_package_lookup
+        string_cases = [
+            'centos-stream10',
+            'redhat-based100'
+        ]
+        osinfo_cases = [
+            {
+                'name' => 'linux', 'os' => nil, 'distro' => 'redhat-based',
+                'major_version' => '9'
+            },
+            {
+                'name' => 'linux', 'os' => nil, 'distro' => 'redhat-based',
+                'major_version' => '11'
+            },
+            {
+                'name' => 'linux', 'os' => nil, 'distro' => 'unknown',
+                'major_version' => '10'
+            }
+        ]
+
+        string_cases.each do |osinfo_id|
+            msg = "#{osinfo_id.inspect} should return false without package lookup"
+            assert_unknown_os_without_package_lookup(osinfo_id, msg)
+        end
+        osinfo_cases.each do |osinfo|
+            msg = "#{osinfo.inspect} should return false without package lookup"
+            assert_unsupported_osinfo_without_package_lookup(osinfo, msg)
+        end
+    end
+
+    def test_detect_distro_stores_major_version
+        h = helper
+        h.define_singleton_method(:show_wait_spinner) {|&block| block.call }
+        xml = <<~XML
+            <operatingsystems>
+              <operatingsystem>
+                <name>linux</name>
+                <distro>redhat-based</distro>
+                <major_version>10</major_version>
+                <package_format>rpm</package_format>
+                <osinfo/>
+                <mountpoints>
+                  <mountpoint dev="/dev/sda1">/</mountpoint>
+                </mountpoints>
+                <product_name>AlmaLinux release 10.2</product_name>
+              </operatingsystem>
+            </operatingsystems>
+        XML
+
+        original_capture2 = Open3.method(:capture2)
+        Open3.define_singleton_method(:capture2) do |_cmd|
+            [xml, OpenStruct.new(:success? => true)]
+        end
+
+        osinfo = h.send(:detect_distro, '/tmp/disk.qcow2')
+
+        assert_equal '10', osinfo['major_version']
+    ensure
+        Open3.define_singleton_method(:capture2, original_capture2)
+    end
+
+    def test_rhel10_package_selection_uses_el10_rpm_pattern
+        Dir.mktmpdir do |dir|
+            package = File.join(dir, 'one-context-7.2.1-0.el10.noarch.rpm')
+            File.write(package, '')
+
+            h = helper
+            h.instance_variable_set(:@options, {
+                :context => dir,
+                :inject_dns => false
+            })
+
+            assert_equal package, h.send(:detect_context_package, 'rhel10')
+        end
+    end
+
+    def assert_unknown_os_without_package_lookup(osinfo_id, message = nil)
+        assert_unsupported_osinfo_without_package_lookup({
+            'name' => 'linux',
+            'os' => osinfo_id
+        }, message)
+    end
+
+    def assert_unsupported_osinfo_without_package_lookup(osinfo, message = nil)
+        h = helper
+        h.define_singleton_method(:detect_context_package) do |family|
+            raise "unexpected package lookup for #{family}"
+        end
+
+        assert_equal false, h.send(:context_command, '/tmp/disk.qcow2', osinfo), message
+    end
+
+end


### PR DESCRIPTION
### Description

Synchronize OneSwap guest OS mappings with the guest systems currently
supported by one-apps.

#### Changes

- Add AlmaLinux, Rocky Linux, Oracle Linux and CentOS Stream aliases for EL8/EL9.
- Add RHEL, AlmaLinux, Rocky Linux and Oracle Linux 10 mappings.
- Add EL10 one-context package selection.
- Support libguestfs EL10 identifiers such as `redhat-based10.2`.
- Add SLED to the SUSE package family.
- Safely handle missing or unsupported osinfo identifiers.
- Add focused mapping and package-selection tests.

#### Runtime verification

- Rocky Linux 9 selected the EL9 one-context RPM.
- AlmaLinux 10.2 selected and injected the EL10 one-context RPM.
- Ubuntu 26.04 selected and injected the Debian one-context package.
- OpenNebula images and VM templates were created successfully.

#№№# Tests

- Added `tests/context_command_os_mapping_test.rb`.
  - Covers EL8, EL9 and EL10 aliases.
  - Covers `redhat-based10` and `redhat-based10.x`.
  - Covers EL10 fallback based on `distro` and `major_version`.
  - Covers SLED, Ubuntu and existing distro mappings.
  - Covers unsupported and malformed OS identifiers.
  - Covers EL10 RPM package selection.
  - Focused mapping tests: 6 runs, 138 assertions, 0 failures.

### Branches to which this PR applies

- [x] master
