### PR TITLE
F #789: Add shift api submodule Add NetApp Shift functionality.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/shift-api-automation"]
-	path = scripts/shift-api-automation
-	url = git@github.com:NetApp/shift-api-automation.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/shift-api-automation"]
+	path = scripts/shift-api-automation
+	url = git@github.com:NetApp/shift-api-automation.git

--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ oneswap convert $VOPTS $SOPTS
 # Convert the blueprint once, but only import selected VMs (in this order)
 oneswap convert $VOPTS $SOPTS --vms vm-web-01,vm-db-01
 
-# Import a single VM whose disks were already converted (re-runs, recovery)
+# Import more VMs later; the blueprint is not executed again
+oneswap convert vm-app-01 $VOPTS $SOPTS
+
+# Import without contacting Shift at all (disks known to be on the mount)
 oneswap convert vm-web-01 $VOPTS $SOPTS --shift-skip-conversion
 ```
 
@@ -186,6 +189,14 @@ Notes:
 - A blueprint execution converts **every** VM in its resource group(s), in
   parallel, regardless of which VMs are then imported. Keep blueprints
   aligned with what you intend to import.
+- One execution serves every later `oneswap convert` against that blueprint.
+  OneSwap checks the blueprint state first and, if it has already converted,
+  reuses the disks on the mount instead of executing again -- Shift rejects a
+  second execution until the previous one is cleared. If an execution is
+  still running, OneSwap attaches to it and waits instead of starting another.
+  To genuinely convert again, clear the blueprint execution in the Shift UI
+  (or with the `removeBpJobs.ps1` script NetApp ships) and re-run.
+  `--shift-skip-conversion` is only needed to skip talking to Shift entirely.
 - The OS morph (`virt-v2v-in-place`) and context injection modify the qcow2
   files on the datastore in place -- there is no local copy, so terabyte
   disks work on workers with small local storage. To regenerate a disk,

--- a/README.md
+++ b/README.md
@@ -145,6 +145,57 @@ indefinitely. Either finish with `--delta --delta-commit` or run
 For detailed behavior, metric selection, confidence levels, and examples, see
 the official OpenNebula documentation.
 
+## NetApp Shift Conversion
+
+With `--shift`, the VMDK-to-qcow2 disk conversion is delegated to a
+[NetApp Shift Toolkit](https://docs.netapp.com/us-en/netapp-solutions/shift-toolkit/shift-overview.html)
+appliance instead of virt-v2v. Shift converts on the ONTAP storage side
+(FlexClone based), so the disks never travel through the OneSwap worker.
+OneSwap still gathers VM properties from vCenter, runs the guest
+customization (context, VirtIO, QEMU Guest Agent) and creates the OpenNebula
+images and template.
+
+Prerequisites, all created in the Shift UI beforehand:
+
+- A source site (vCenter + ONTAP) and a destination site.
+- One or more resource groups containing the VMs to convert.
+- A blueprint (DR plan) referencing those resource groups.
+- The source NFS datastore mounted locally on the OneSwap host
+  (`--shift-mount`); Shift writes `<vm-name>.qcow2` (plus
+  `<vm-name>_1.qcow2`, ... for additional disks) next to each VM folder.
+- `virt-v2v-in-place` installed, and the Python dependencies of the vendored
+  shift-api-automation scripts (`pip install requests envyaml pymongo`).
+- Source VMs powered off.
+
+```
+SOPTS='--shift https://<shift-ip> --shift-user admin --shift-pass ...'
+SOPTS="$SOPTS --shift-blueprint bp1 --shift-mount /mnt/shift"
+
+# Convert and import every VM in the blueprint
+oneswap convert $VOPTS $SOPTS
+
+# Convert the blueprint once, but only import selected VMs (in this order)
+oneswap convert $VOPTS $SOPTS --vms vm-web-01,vm-db-01
+
+# Import a single VM whose disks were already converted (re-runs, recovery)
+oneswap convert vm-web-01 $VOPTS $SOPTS --shift-skip-conversion
+```
+
+Notes:
+
+- A blueprint execution converts **every** VM in its resource group(s), in
+  parallel, regardless of which VMs are then imported. Keep blueprints
+  aligned with what you intend to import.
+- The OS morph (`virt-v2v-in-place`) and context injection modify the qcow2
+  files on the datastore in place -- there is no local copy, so terabyte
+  disks work on workers with small local storage. To regenerate a disk,
+  re-run the blueprint in the Shift UI; re-importing an already imported VM
+  without regenerating it is unsupported (the guest would be morphed twice).
+- The wait for the blueprint execution runs until it finishes; interrupt
+  with Ctrl+C or bound it with `:shift_wait_timeout:` in `oneswap.yaml`.
+- `--shift` cannot be combined with `--delta`, `--hybrid`, `--custom`,
+  `--fallback`, `--vddk`, `--esxi`, `--clone` or `--dry-run`.
+
 ## vCenter Permissions Requirements
 
 OneSwap requires specific vCenter permissions depending on the conversion mode used. Below are the required privileges for vCenter 8.

--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ Prerequisites, all created in the Shift UI beforehand:
 - The source NFS datastore mounted locally on the OneSwap host
   (`--shift-mount`); Shift writes `<vm-name>.qcow2` (plus
   `<vm-name>_1.qcow2`, ... for additional disks) next to each VM folder.
-- `virt-v2v-in-place` installed, and the Python dependencies of the vendored
-  shift-api-automation scripts (`pip install requests envyaml pymongo`).
+- `virt-v2v-in-place` installed on the conversion host.
 - Source VMs powered off.
 
 ```

--- a/README.md
+++ b/README.md
@@ -164,10 +164,50 @@ Prerequisites, all created in the Shift UI beforehand:
   (`--shift-mount`); Shift writes `<vm-name>.qcow2` (plus
   `<vm-name>_1.qcow2`, ... for additional disks) next to each VM folder.
 - `virt-v2v-in-place` installed on the conversion host.
-- Source VMs powered off.
+- vCenter credentials, same as any other conversion mode: the VM properties,
+  NICs and tags the OpenNebula template is built from still come from vCenter,
+  even though the disks do not.
+
+Power state is awkward, and the two Shift operations disagree about it:
+
+- The **compliance check** wants the VMs powered **on**. With them off it
+  reports them as failed resources (`{"powerState":"POWERED_OFF"}`), even
+  though the conversion then runs perfectly well.
+- The **convert** execution wants them powered **off**, and rejects the
+  trigger otherwise (`ERSCSTEX022`, naming the offenders, and checking every
+  VM in the blueprint rather than just the one being imported). This is the
+  dismissable warning the Shift UI shows with a "Continue" button;
+  `--shift-ignore-running-vms` is the same override, and OneSwap names the
+  flag in the error so a failed run tells you how to retry.
+
+Converting a running VM uses a point-in-time snapshot, so the resulting disks
+are crash-consistent rather than quiesced — fine for most guests, but not for
+a database you care about. Powering the VM down first is still the safer path.
+
+Two workable combinations:
+
+```
+# VMs powered off; the compliance check objects to that, so skip it
+oneswap convert $VOPTS $SOPTS --shift-skip-compliance
+
+# VMs left running; compliance passes, convert needs the override
+oneswap convert $VOPTS $SOPTS --shift-ignore-running-vms
+```
+
+Importing is unaffected by either: once the disks exist, OneSwap only reads
+qcow2 files from the mount, so power state and snapshots are irrelevant. That
+is why the powered-off/no-snapshot preconditions the other modes enforce are
+skipped in Shift mode — and Shift's own clone leaves a snapshot behind anyway.
 
 ```
 SOPTS='--shift https://<shift-ip> --shift-user admin --shift-pass ...'
+
+# Which blueprints exist, and how many VMs each covers
+oneswap list blueprints $SOPTS
+
+# Which VMs a blueprint would convert
+oneswap list vms $SOPTS --shift-blueprint bp1
+
 SOPTS="$SOPTS --shift-blueprint bp1 --shift-mount /mnt/shift"
 
 # Convert and import every VM in the blueprint
@@ -181,13 +221,32 @@ oneswap convert vm-app-01 $VOPTS $SOPTS
 
 # Import without contacting Shift at all (disks known to be on the mount)
 oneswap convert vm-web-01 $VOPTS $SOPTS --shift-skip-conversion
+
+# Trigger the blueprint but skip the compliance check (already checked, or resuming)
+oneswap convert $VOPTS $SOPTS --shift-skip-compliance
+
+# Import without the OS morph, for guests virt-v2v refuses to convert
+oneswap convert alpine-vm $VOPTS $SOPTS --shift-skip-morph
 ```
+
+After the disks are converted, OneSwap runs `virt-v2v-in-place` on them to
+install virtio drivers and fix the initramfs and bootloader for KVM. virt-v2v
+only recognises guests it has support for, and rejects the rest with
+`virt-v2v is unable to convert this guest type` — Alpine among them. Guests
+like that usually boot on KVM unmodified because virtio is already built in,
+so `--shift-skip-morph` imports the converted disks as they are. OneSwap names
+the flag in the error when it hits that case.
 
 Notes:
 
 - A blueprint execution converts **every** VM in its resource group(s), in
   parallel, regardless of which VMs are then imported. Keep blueprints
-  aligned with what you intend to import.
+  aligned with what you intend to import — `oneswap list blueprints` and
+  `oneswap list vms --shift-blueprint <name>` show what you are committing to
+  before you run anything.
+- `oneswap list vms` reads from Shift whenever `--shift` (or `:shift:` in the
+  config file) is set, and from vCenter otherwise. `list datacenters` and
+  `list clusters` are vCenter concepts and always use vCenter.
 - One execution serves every later `oneswap convert` against that blueprint.
   OneSwap checks the blueprint state first and, if it has already converted,
   reuses the disks on the mount instead of executing again -- Shift rejects a

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,7 @@ INSTALL_FILES=(
 BIN_FILES="oneswap sesparse"
 ONE_CLI_LIB_FILES="esxi_client.rb \
                    esxi_vm.rb \
+                   netapp_shift_helper.rb \
                    oneswap_helper.rb \
                    oneswap_logger.rb \
                    vsphere_client.rb \

--- a/netapp_shift_helper.rb
+++ b/netapp_shift_helper.rb
@@ -23,11 +23,7 @@ require 'uri'
 # NetApp Shift Toolkit client for OneSwap.
 #
 # Talks to the Shift appliance REST API directly. The endpoints, ports and
-# payloads mirror NetApp's own shift-api-automation Python modules, which this
-# replaced -- those scripts are not a library (each reads a fixed JSON file
-# next to itself and reports results only by logging to stderr), and the six
-# endpoints OneSwap needs are thin enough that wrapping them in Ruby is less
-# code than driving the scripts as subprocesses.
+# payloads mirror NetApp's own shift-api-automation Python modules.
 #
 # Services live on three ports:
 #
@@ -80,26 +76,71 @@ module NetAppShift
     # OneSwap stays read-only against that API.
     class AlreadyExecuted < OperationError; end
 
+    # Shift refuses to convert while any VM in the blueprint is running,
+    # unless the caller opts in to a point-in-time snapshot of the live VM.
+    # Carries the names the appliance reported so the caller can act on them.
+    class PoweredOnVms < OperationError
+
+        attr_reader :vm_names
+
+        def initialize(message = nil, code: nil, http_status: nil, vm_names: [])
+            super(message, :code => code, :http_status => http_status)
+            @vm_names = vm_names
+        end
+
+    end
+
     class Helper
 
         SESSION_PORT  = 3698
         SETUP_PORT    = 3700
         RECOVERY_PORT = 3704
 
-        # Execution types. "convert" is the disk-only workflow OneSwap wants:
-        # it converts the VMDKs on the ONTAP volume without building a VM on
-        # the target hypervisor. "migrate" additionally creates and configures
-        # the target VM.
+        # The only execution type OneSwap uses. Shift also offers "migrate",
+        # which builds a VM on the destination hypervisor -- not possible here,
+        # because the destination is a qcow2 on an NFS export rather than a
+        # hypervisor Shift can drive.
         CONVERSION = 'convert'.freeze
-        MIGRATION  = 'migrate'.freeze
 
-        # Job step states. Everything else means the step is still pending or
-        # running.
-        STEP_SUCCESS = 4
-        STEP_FAILED  = 5
+        # Terminal states, shared by job steps and executions. Everything else
+        # means still pending or running.
+        STATE_SUCCESS = 4
+        STATE_FAILED  = 5
+
+        # API paths. Collected here because the appliance is inconsistent
+        # about casing -- the status collection is "drplan", the per-plan
+        # execution path is "drPlan". Both are verified against a live
+        # appliance; neither is a typo to be "corrected".
+        PATH_SITES            = '/api/setup/site'.freeze
+        PATH_BLUEPRINTS       = '/api/setup/drplan'.freeze
+        PATH_RESOURCE_GROUPS  = '/api/setup/protectionGroup'.freeze
+        PATH_BLUEPRINT_STATUS = '/api/recovery/drplan/status'.freeze
+
+        def self.path_compliance_request(blueprint_id)
+            "/api/setup/compliance/drplan/#{blueprint_id}/checkrequest?async=true"
+        end
+
+        # The task id goes in both the path and the query string; that is what
+        # the appliance expects, odd as it reads.
+        def self.path_compliance_status(task_id)
+            "/api/setup/compliance/drplan/#{task_id}/checkrequest?taskId=#{task_id}"
+        end
+
+        def self.path_execution(blueprint_id, mode)
+            "/api/recovery/drPlan/#{blueprint_id}/#{mode}/execution"
+        end
+
+        def self.path_execution_steps(execution_id)
+            "/api/recovery/execution/#{execution_id}/steps"
+        end
 
         # Returned when a blueprint has already been executed successfully.
         ERR_ALREADY_EXECUTED = 'ERSCSTEX009'.freeze
+
+        # Returned when a VM in the blueprint is still running. Overridable
+        # with the ignorePoweredOnVms flag, which is what the Shift UI sends
+        # when its "Continue" prompt is accepted.
+        ERR_VMS_POWERED_ON = 'ERSCSTEX022'.freeze
 
         DEFAULTS = {
             # Per-request socket timeouts.
@@ -150,50 +191,99 @@ module NetAppShift
         # Sites registered on the appliance. Cheap connectivity and credential
         # preflight.
         def sites
-            api_session {|sid| api_list(sid, SETUP_PORT, '/api/setup/site') }
+            api_session {|sid| api_list(sid, SETUP_PORT, PATH_SITES) }
         end
 
         # Blueprints registered on the appliance.
         def blueprints
-            api_session {|sid| api_list(sid, SETUP_PORT, '/api/setup/drplan') }
+            api_session {|sid| api_list(sid, SETUP_PORT, PATH_BLUEPRINTS) }
         end
 
-        # VM names a blueprint covers, in resource-group order. This is what
-        # one execution of it will convert.
+        # VMs a blueprint covers, in resource-group order. This is what one
+        # execution of it will convert.
         #
-        # @return [Array<String>]
-        def blueprint_vm_names(blueprint_name)
+        # @return [Array<Hash>] :name, :id, :resource_group
+        def blueprint_vms(blueprint_name)
             api_session do |sid|
                 blueprint = find_blueprint(sid, blueprint_name)
 
                 rg_ids = Array(blueprint['protectionGroups']).map {|rg| rg['_id'] }.compact
-                groups = api_list(sid, SETUP_PORT, '/api/setup/protectionGroup')
+                groups = api_list(sid, SETUP_PORT, PATH_RESOURCE_GROUPS)
                          .select {|rg| rg_ids.include?(rg['_id']) }
 
-                names = groups.flat_map {|rg| Array(rg['vms']).map {|vm| vm['name'] } }.compact
+                vms = groups.flat_map do |rg|
+                    Array(rg['vms']).map do |vm|
+                        # Logged so the fields the appliance actually returns
+                        # can be surfaced as columns without guessing at them.
+                        @logger.debug("NetApp Shift: blueprint VM -> #{vm.inspect}")
 
-                if names.empty?
+                        { :name           => vm['name'],
+                          :id             => vm['_id'],
+                          :resource_group => rg['name'] }
+                    end
+                end.reject {|vm| vm[:name].nil? }
+
+                if vms.empty?
                     raise OperationError,
                           "Blueprint '#{blueprint_name}' has no VMs in its resource group(s)"
                 end
 
-                names
+                vms
+            end
+        end
+
+        # Just the names, in the same order.
+        #
+        # @return [Array<String>]
+        def blueprint_vm_names(blueprint_name)
+            blueprint_vms(blueprint_name).map {|vm| vm[:name] }
+        end
+
+        # Every blueprint on the appliance with the resource groups and VMs it
+        # covers, for choosing which one to run.
+        #
+        # @return [Array<Hash>] :name, :id, :resource_groups, :vms
+        def blueprint_summaries
+            api_session do |sid|
+                by_id = api_list(sid, SETUP_PORT, PATH_RESOURCE_GROUPS)
+                        .each_with_object({}) {|rg, acc| acc[rg['_id']] = rg }
+
+                api_list(sid, SETUP_PORT, PATH_BLUEPRINTS).map do |bp|
+                    groups = Array(bp['protectionGroups']).map {|rg| by_id[rg['_id']] }.compact
+
+                    {
+                        :name            => bp['name'],
+                        :id              => bp['_id'],
+                        :resource_groups => groups.map {|rg| rg['name'] }.compact,
+                        :vms             => groups.flat_map do |rg|
+                            Array(rg['vms']).map {|vm| vm['name'] }
+                        end.compact
+                    }
+                end
             end
         end
 
         # Whether a blueprint has already run, is running, or failed -- nil if
         # it has never run or the appliance does not list it.
         #
-        # Best effort, and only an optimisation: it saves a pointless
-        # compliance check and trigger. The reliable signal that a blueprint
-        # cannot run again is the AlreadyExecuted raised by
-        # #trigger_conversion.
+        # Read from the blueprint's lastExecution, which carries a numeric
+        # status and the execution type:
         #
-        # @return [Hash, nil] :status, :execution_id, :complete, :failed, :running
+        #   {"drPlan" => {"_id" => .., "name" => ..},
+        #    "lastExecution" => {"_id" => .., "status" => 4, "type" => "convert"}}
+        #
+        # (NetApp's own client read a "recoveryStatus" string off drPlan
+        # instead; appliances in the field do not return that field.)
+        #
+        # Still only an optimisation -- it saves a pointless compliance check
+        # and trigger. The reliable signal that a blueprint cannot run again
+        # is the AlreadyExecuted raised by #trigger_conversion.
+        #
+        # @return [Hash, nil] :status, :type, :execution_id, :complete, :failed, :running
         def blueprint_execution_state(blueprint_name)
             api_session do |sid|
                 id       = find_blueprint(sid, blueprint_name)['_id']
-                response = api_get(sid, RECOVERY_PORT, '/api/recovery/drplan/status')
+                response = api_get(sid, RECOVERY_PORT, PATH_BLUEPRINT_STATUS)
 
                 @logger.debug("NetApp Shift: drplan/status -> #{response.inspect}")
 
@@ -207,28 +297,34 @@ module NetAppShift
                     next nil
                 end
 
-                status = entry.dig('drPlan', 'recoveryStatus').to_s
+                last = entry['lastExecution']
 
-                next nil if status.empty?
+                if last.nil?
+                    @logger.debug("NetApp Shift: blueprint #{id} has no lastExecution")
+                    next nil
+                end
+
+                status = last['status']
 
                 {
                     :status       => status,
-                    :execution_id => entry.dig('lastExecution', '_id'),
-                    :complete     => status.include?('complete'),
-                    :failed       => status.include?('error'),
-                    :running      => !status.match?(/complete|error/)
+                    :type         => last['type'],
+                    :execution_id => last['_id'],
+                    :complete     => status == STATE_SUCCESS,
+                    :failed       => status == STATE_FAILED,
+                    :running      => ![STATE_SUCCESS, STATE_FAILED].include?(status)
                 }
             end
         end
 
         # Job steps of an execution. Each carries a 'description' and a
-        # 'status' (see STEP_SUCCESS / STEP_FAILED).
+        # 'status' (see STATE_SUCCESS / STATE_FAILED).
         #
         # @return [Array<Hash>]
         def job_steps(execution_id)
             api_session do |sid|
                 response = api_get(sid, RECOVERY_PORT,
-                                   "/api/recovery/execution/#{execution_id}/steps")
+                                   self.class.path_execution_steps(execution_id))
 
                 Array(response['steps'])
             end
@@ -301,7 +397,7 @@ module NetAppShift
                 id = find_blueprint(sid, blueprint_name)['_id']
 
                 started = api_post(sid, SETUP_PORT,
-                                   "/api/setup/compliance/drplan/#{id}/checkrequest?async=true",
+                                   self.class.path_compliance_request(id),
                                    :timeout => @timeouts[:compliance_timeout])
 
                 task_id = started['taskId']
@@ -320,9 +416,14 @@ module NetAppShift
         # Execute a blueprint. With CONVERSION this converts the disks only;
         # no VM is built on the target hypervisor.
         #
+        # @param ignore_powered_on [Boolean] convert from a point-in-time
+        #   snapshot even if VMs in the blueprint are running. This is the
+        #   override behind the Shift UI's "Continue" prompt; the resulting
+        #   image is crash-consistent, not quiesced.
         # @return [String] the execution id
         # @raise [AlreadyExecuted] if the blueprint has already converted
-        def trigger_conversion(blueprint_name, mode = CONVERSION)
+        # @raise [PoweredOnVms] if VMs are running and the override is off
+        def trigger_conversion(blueprint_name, ignore_powered_on: false)
             api_session do |sid|
                 id = find_blueprint(sid, blueprint_name)['_id']
 
@@ -333,10 +434,12 @@ module NetAppShift
                     }
                 }
 
-                # Note the capital P: this path is drPlan, unlike the lowercase
-                # drplan of /api/recovery/drplan/status.
+                # Only added when asked for, so the default request stays
+                # byte-identical to the one already known to work.
+                payload['ignorePoweredOnVms'] = true if ignore_powered_on
+
                 response = api_post(sid, RECOVERY_PORT,
-                                    "/api/recovery/drPlan/#{id}/#{mode}/execution",
+                                    self.class.path_execution(id, CONVERSION),
                                     :body => payload)
 
                 execution_id = response['_id'] || deep_find(response, '_id')
@@ -373,7 +476,7 @@ module NetAppShift
                 when :complete
                     return { :status => 'complete', :steps => steps }
                 when :failed
-                    failed = steps.select {|s| s['status'] == STEP_FAILED }
+                    failed = steps.select {|s| s['status'] == STATE_FAILED }
                                   .map {|s| s['description'] }.compact
                     raise OperationError,
                           "Shift execution #{execution_id} of '#{blueprint_name}' failed" \
@@ -402,8 +505,8 @@ module NetAppShift
 
             statuses = steps.map {|s| s['status'] }
 
-            return :failed   if statuses.include?(STEP_FAILED)
-            return :complete if statuses.all? {|s| s == STEP_SUCCESS }
+            return :failed   if statuses.include?(STATE_FAILED)
+            return :complete if statuses.all? {|s| s == STATE_SUCCESS }
 
             :running
         end
@@ -413,17 +516,20 @@ module NetAppShift
             interval = @timeouts[:compliance_poll_interval].to_f
 
             limit.times do
-                # The task id goes in both the path and the query string; that
-                # is what the appliance expects, odd as it reads.
                 response = api_post(session_id, SETUP_PORT,
-                                    "/api/setup/compliance/drplan/#{task_id}" \
-                                    "/checkrequest?taskId=#{task_id}",
+                                    self.class.path_compliance_status(task_id),
                                     :timeout => @timeouts[:compliance_timeout])
 
                 status = response['status'].to_s
 
-                return { :task_id => task_id, :result => response['result'] } if
-                    status == 'succeeded'
+                if status == 'succeeded'
+                    # The result carries the appliance's per-check findings.
+                    # Logged rather than discarded so a check that "passed"
+                    # but flagged something is still visible.
+                    @logger.debug("NetApp Shift: compliance result -> #{response['result'].inspect}")
+
+                    return { :task_id => task_id, :result => response['result'] }
+                end
 
                 if ['failed', 'error'].include?(status)
                     raise OperationError,
@@ -441,7 +547,7 @@ module NetAppShift
         end
 
         def find_blueprint(session_id, blueprint_name)
-            all       = api_list(session_id, SETUP_PORT, '/api/setup/drplan')
+            all       = api_list(session_id, SETUP_PORT, PATH_BLUEPRINTS)
             blueprint = all.find {|bp| bp['name'] == blueprint_name }
 
             if blueprint.nil?
@@ -558,7 +664,11 @@ module NetAppShift
                 nil
             end
 
-            detail = parsed.is_a?(Hash) ? (Array(parsed['errors']).first || parsed) : nil
+            # The appliance's top-level "message" is often the literal string
+            # "[object Object]", so the first entry of "errors" is the one
+            # worth reading. Later entries carry structured detail instead.
+            errors  = parsed.is_a?(Hash) ? Array(parsed['errors']).select {|e| e.is_a?(Hash) } : []
+            detail  = errors.first || (parsed.is_a?(Hash) ? parsed : nil)
             code    = detail.is_a?(Hash) ? detail['code'] : nil
             message = (detail.is_a?(Hash) && detail['message']) ||
                       response.body.to_s[0, 300]
@@ -567,6 +677,15 @@ module NetAppShift
                 raise AlreadyExecuted.new(message.to_s,
                                           :code => code,
                                           :http_status => response.code.to_i)
+            end
+
+            if code == ERR_VMS_POWERED_ON
+                raise PoweredOnVms.new(
+                    message.to_s,
+                    :code        => code,
+                    :http_status => response.code.to_i,
+                    :vm_names    => errors.flat_map {|e| Array(e['poweredOnVmNames']) }.compact.uniq
+                )
             end
 
             raise OperationError.new(

--- a/netapp_shift_helper.rb
+++ b/netapp_shift_helper.rb
@@ -154,9 +154,11 @@ module NetAppShift
         MIGRATION  = 'clone_based_migration'.freeze
 
         # Appliance service ports, matching the Python API modules: the tenant
-        # session service and the setup service (sites/resource groups/plans).
-        SESSION_PORT = 3698
-        SETUP_PORT   = 3700
+        # session service, the setup service (sites/resource groups/plans) and
+        # the recovery service (executions/job status).
+        SESSION_PORT  = 3698
+        SETUP_PORT    = 3700
+        RECOVERY_PORT = 3704
 
         # operation => basename shared by the script and its JSON payload.
         # The payload path is fixed by Config.yml, so it cannot be overridden
@@ -404,6 +406,60 @@ module NetAppShift
             end
         end
 
+        # Current execution state of a blueprint, or nil if it has never run.
+        #
+        # This is what makes repeat invocations work: a blueprint that has
+        # already executed cannot be executed again until its prior executions
+        # are deleted (NetApp ships PowerShell/removeBpJobs.ps1 for that), and
+        # one execution converts every VM in the resource group anyway. So the
+        # caller checks here first and imports the existing disks instead of
+        # triggering a second time.
+        #
+        # GET :3704/api/recovery/drplan/status returns a list of
+        #   { 'drPlan' => {'_id', 'recoveryStatus'}, 'lastExecution' => {'_id', 'status'} }
+        # recoveryStatus is the same string verify_blueprint_status keys off:
+        # it contains "complete" or "error" once terminal.
+        #
+        # Note this is only an optimisation: it saves a pointless compliance
+        # check and trigger. The authoritative signal that a blueprint cannot
+        # run again is the ERSCSTEX009 error the trigger itself returns, which
+        # #parse_trigger_migration reports as :already_executed.
+        #
+        # @return [Hash, nil] :status, :execution_id, :complete, :failed, :running
+        def blueprint_execution_state(blueprint_name)
+            api_session do |sid|
+                id       = api_find_blueprint(sid, blueprint_name)['_id']
+                response = api_get(sid, RECOVERY_PORT, '/api/recovery/drplan/status')
+
+                @logger.debug("NetApp Shift: drplan/status -> #{response.inspect}")
+
+                # Bare array in the appliances seen so far, but tolerate the
+                # setup service's {'list' => [...]} envelope too.
+                entries = response.is_a?(Hash) ? Array(response['list']) : Array(response)
+
+                entry = entries.find do |e|
+                    e.is_a?(Hash) && e.dig('drPlan', '_id') == id
+                end
+
+                if entry.nil?
+                    @logger.debug("NetApp Shift: blueprint #{id} not present in drplan/status")
+                    next nil
+                end
+
+                status = entry.dig('drPlan', 'recoveryStatus').to_s
+
+                next nil if status.empty?
+
+                {
+                    :status       => status,
+                    :execution_id => entry.dig('lastExecution', '_id'),
+                    :complete     => status.include?('complete'),
+                    :failed       => status.include?('error'),
+                    :running      => !status.match?(/complete|error/)
+                }
+            end
+        end
+
         # ------------------------------------------------------------------ #
         # Locating the converted disks                                        #
         # ------------------------------------------------------------------ #
@@ -499,10 +555,14 @@ module NetAppShift
         def check!(result)
             return result if result.ok?
 
+            # The scripts log root cause first and a generic trailer last
+            # ("Migration trigger failed for migration index 1"), so prefer
+            # the line carrying the HTTP status and response body.
             reason = if result.timed_out?
                          "timed out after #{result.duration}s"
                      elsif result.errors.any?
-                         result.errors.last
+                         result.errors.find {|e| e.include?('Response code') } ||
+                             result.errors.first
                      else
                          'the script logged no success message'
                      end
@@ -647,6 +707,13 @@ module NetAppShift
             response = api_request(Net::HTTP::Get, SETUP_PORT, path, :session => session_id)
 
             Array(response['list'])
+        end
+
+        # GET a path on any service port, returning the parsed body as-is.
+        # The recovery endpoints answer with a bare array rather than the
+        # setup service's {'list' => [...]} envelope.
+        def api_get(session_id, port, path)
+            api_request(Net::HTTP::Get, port, path, :session => session_id)
         end
 
         def api_find_blueprint(session_id, blueprint_name)
@@ -897,10 +964,20 @@ module NetAppShift
             }
         end
 
+        # Shift refuses to execute a blueprint that already converted
+        # successfully, with ERSCSTEX009 "No further execution is allowed".
+        # That is not a failure for OneSwap -- the disks it needs are already
+        # on the datastore -- so it is reported separately from :ok.
+        ALREADY_EXECUTED = /ERSCSTEX009|No further execution is allowed/i.freeze
+
         def parse_trigger_migration(output)
             id = output[/Migration triggered for blueprint .* with execution id:\s*(\S+)/, 1]
 
-            { :ok => !id.nil?, :execution_id => id }
+            {
+                :ok               => !id.nil?,
+                :execution_id     => id,
+                :already_executed => id.nil? && output.match?(ALREADY_EXECUTED)
+            }
         end
 
         def parse_migration_status(output)

--- a/netapp_shift_helper.rb
+++ b/netapp_shift_helper.rb
@@ -14,47 +14,31 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-require 'digest'
-require 'fileutils'
 require 'json'
 require 'logger'
 require 'net/http'
-require 'open3'
 require 'openssl'
-require 'tmpdir'
 require 'uri'
 
-# NetApp Shift integration for OneSwap.
+# NetApp Shift Toolkit client for OneSwap.
 #
-# This is a thin wrapper around the vendored NetApp "shift-api-automation"
-# Python scripts (scripts/shift-api-automation/Python, a git submodule).
+# Talks to the Shift appliance REST API directly. The endpoints, ports and
+# payloads mirror NetApp's own shift-api-automation Python modules, which this
+# replaced -- those scripts are not a library (each reads a fixed JSON file
+# next to itself and reports results only by logging to stderr), and the six
+# endpoints OneSwap needs are thin enough that wrapping them in Ruby is less
+# code than driving the scripts as subprocesses.
 #
-# The upstream scripts are not a library: each one reads a *fixed* JSON file
-# next to itself (the path comes from Config.yml via conftest.py), talks to the
-# Shift appliance, and reports what happened by *logging* to stderr. There is
-# no structured output and no meaningful exit code -- the top-level scripts
-# swallow exceptions and still exit 0.
+# Services live on three ports:
 #
-# So the wrapper does three things for each operation:
+#   3698  tenant sessions
+#   3700  setup      -- sites, resource groups, blueprints, compliance
+#   3704  recovery   -- executions and job steps
 #
-#   1. Build the "executions" JSON payload and write it to the path the script
-#      expects, restoring the original file afterwards (the payload holds
-#      plaintext credentials, so it is chmod 0600 while it exists).
-#   2. Run the script with CWD set to the Python directory (its imports and its
-#      logs/ directory are both relative to it).
-#   3. Scrape the captured output for the identifiers and statuses the script
-#      logged, and hand them back as a NetAppShift::Result.
-#
-# The Shift workflow OneSwap drives: the operator pre-creates the source site,
-# destination site, resource group(s) and blueprint in the Shift UI. OneSwap
-# then runs the compliance check, triggers the blueprint execution in
-# "clone_based_conversion" mode (which converts every VM in the blueprint's
-# resource groups in parallel) and waits for it to finish. The converted disks
-# appear on the source NFS datastore next to each VM's folder:
-#
-#   <mount>/<vm-name>.qcow2         first disk
-#   <mount>/<vm-name>_1.qcow2       second disk
-#   <mount>/<vm-name>_2.qcow2       third disk, ...
+# The division of labour with the Shift UI is deliberate: an operator creates
+# the source site, destination site, resource group(s) and blueprint by hand,
+# which is how they choose which wave of VMs moves when. OneSwap only runs a
+# blueprint and imports what comes out, and never writes to the setup side.
 #
 #   shift = NetAppShift::Helper.new(
 #       :server   => 'https://10.0.0.5',
@@ -63,10 +47,10 @@ require 'uri'
 #       :logger   => @logger
 #   )
 #
-#   shift.blueprint_vm_names('bp1')                 # => ['web01', 'db01']
-#   shift.check!(shift.run_compliance_check('bp1'))
-#   trigger = shift.check!(shift.trigger_migration('bp1'))
-#   shift.wait_for_completion('bp1', trigger[:execution_id])
+#   shift.blueprint_vm_names('bp1')       # => ['web01', 'db01']
+#   shift.run_compliance_check('bp1')
+#   id = shift.trigger_conversion('bp1')  # raises AlreadyExecuted if it ran
+#   shift.wait_for_completion('bp1', id)
 #   shift.converted_disks('web01', '/mnt/shift', 2)
 #   # => ['/mnt/shift/web01.qcow2', '/mnt/shift/web01_1.qcow2']
 #
@@ -74,137 +58,72 @@ module NetAppShift
 
     class Error < StandardError; end
 
-    # Raised when python3 or the vendored scripts/modules are not usable.
-    class DependencyError < Error; end
-
-    # Raised by check!/wait_for_completion/API reads when an operation did not
-    # report success.
+    # The appliance rejected a request, or answered in a shape we cannot use.
     class OperationError < Error
 
-        attr_reader :result
+        attr_reader :code, :http_status
 
-        def initialize(message, result = nil)
+        # message is optional so `raise NetAppShift::AlreadyExecuted` works
+        # like any other exception class.
+        def initialize(message = nil, code: nil, http_status: nil)
             super(message)
-            @result = result
+            @code        = code
+            @http_status = http_status
         end
 
     end
 
-    # Outcome of a single script invocation.
-    class Result
+    # Shift refuses to execute a blueprint that already converted
+    # successfully. For OneSwap that is a no-op rather than a failure: the
+    # disks it wants are already on the datastore. Clearing the previous
+    # execution is a Shift UI action (NetApp ship removeBpJobs.ps1 for it);
+    # OneSwap stays read-only against that API.
+    class AlreadyExecuted < OperationError; end
 
-        attr_reader :operation, :output, :errors, :data, :exit_code, :duration
-
-        def initialize(operation, opts = {})
-            @operation = operation
-            @output    = opts[:output].to_s
-            @errors    = opts[:errors] || []
-            @data      = opts[:data] || {}
-            @exit_code = opts[:exit_code]
-            @duration  = opts[:duration]
-            @timed_out = opts[:timed_out] ? true : false
-        end
-
-        def timed_out?
-            @timed_out
-        end
-
-        # True when the script logged the messages that mean "this worked".
-        # Exit codes are useless here: the upstream scripts catch everything
-        # and still exit 0.
-        def ok?
-            !timed_out? && @data[:ok] == true
-        end
-
-        def [](key)
-            @data[key.to_sym]
-        end
-
-        def to_h
-            @data.merge(
-                :operation => @operation,
-                :ok        => ok?,
-                :timed_out => timed_out?,
-                :exit_code => @exit_code,
-                :duration  => @duration,
-                :errors    => @errors
-            )
-        end
-
-        def to_s
-            "#{@operation}: #{ok? ? 'ok' : 'failed'} (#{@duration}s)"
-        end
-
-    end
-
-    # Wrapper around the vendored shift-api-automation Python scripts, plus a
-    # minimal read-only REST client for the lookups the scripts cannot express
-    # (they log Python repr, not JSON).
     class Helper
 
-        # Vendored submodule, relative to this file.
-        SCRIPT_DIR = File.join(__dir__, 'scripts', 'shift-api-automation', 'Python')
-
-        # Shift workflow types. "clone_based_conversion" is the disk-only
-        # workflow (POST .../convert/execution) OneSwap wants: it converts the
-        # VMDKs on the ONTAP volume without building a VM on the target
-        # hypervisor. "clone_based_migration" (POST .../migrate/execution)
-        # additionally creates and configures the target VM.
-        CONVERSION = 'clone_based_conversion'.freeze
-        MIGRATION  = 'clone_based_migration'.freeze
-
-        # Appliance service ports, matching the Python API modules: the tenant
-        # session service, the setup service (sites/resource groups/plans) and
-        # the recovery service (executions/job status).
         SESSION_PORT  = 3698
         SETUP_PORT    = 3700
         RECOVERY_PORT = 3704
 
-        # operation => basename shared by the script and its JSON payload.
-        # The payload path is fixed by Config.yml, so it cannot be overridden
-        # per run; see #with_payload for how that is handled.
-        OPERATIONS = {
-            :get_site               => 'get_site',
-            :create_blueprint       => 'create_blueprint',
-            :run_compliance_check   => 'run_compliance_check',
-            :trigger_migration      => 'trigger_migration',
-            :check_migration_status => 'check_migration_status'
+        # Execution types. "convert" is the disk-only workflow OneSwap wants:
+        # it converts the VMDKs on the ONTAP volume without building a VM on
+        # the target hypervisor. "migrate" additionally creates and configures
+        # the target VM.
+        CONVERSION = 'convert'.freeze
+        MIGRATION  = 'migrate'.freeze
+
+        # Job step states. Everything else means the step is still pending or
+        # running.
+        STEP_SUCCESS = 4
+        STEP_FAILED  = 5
+
+        # Returned when a blueprint has already been executed successfully.
+        ERR_ALREADY_EXECUTED = 'ERSCSTEX009'.freeze
+
+        DEFAULTS = {
+            # Per-request socket timeouts.
+            :http_timeout             => 30,
+            # Requesting and polling a compliance check are both slow calls.
+            :compliance_timeout       => 300,
+            # A freshly created blueprint needs a moment before it will pass a
+            # compliance check.
+            :compliance_settle        => 20,
+            :compliance_poll_interval => 5,
+            :compliance_poll_limit    => 24,
+            # How often to re-check a running execution.
+            :status_poll_interval     => 30
         }.freeze
 
-        # check_migration_status polls in-process: verify_blueprint_status
-        # loops 40x with a 30s sleep (~20 min) before giving up. The wrapper
-        # ceiling sits above that so it never kills a healthy run;
-        # #wait_for_completion handles executions that outlast the script's
-        # own polling window.
-        DEFAULT_TIMEOUTS = {
-            :get_site               => 120,
-            :create_blueprint       => 600,
-            :run_compliance_check   => 300,
-            :trigger_migration      => 600,
-            :check_migration_status => 2700
-        }.freeze
-
-        # trigger_migration.py imports utils.db_utils at module scope, which
-        # imports pymongo, even though the flow never touches Mongo. It still
-        # has to be installed.
-        PYTHON_MODULES = ['requests', 'envyaml', 'pymongo'].freeze
-
-        attr_reader :logger, :script_dir, :server
+        attr_reader :logger, :server
 
         # @param options [Hash]
-        # @option options :server     [String] Shift appliance base URL, scheme
-        #   and host only. Ports (3698/3700/3704) are appended per service.
-        # @option options :username   [String] Shift login
-        # @option options :password   [String] Shift password
-        # @option options :script_dir [String] override the vendored Python dir
-        # @option options :python     [String] interpreter, default "python3"
-        # @option options :logger     [Logger]
-        # @option options :timeouts   [Hash] per operation overrides, seconds
-        # @option options :execution_name [String] label recorded in payloads
-        # @option options :keep_payload [Boolean] leave the rendered JSON on
-        #   disk after the run (debugging only -- it contains passwords)
-        # @option options :dry_run    [Boolean] build and log payloads without
-        #   invoking Python
+        # @option options :server   [String] appliance base URL, scheme and
+        #   host only -- the service port is appended per call
+        # @option options :username [String]
+        # @option options :password [String]
+        # @option options :logger   [Logger]
+        # @option options :timeouts [Hash] overrides for DEFAULTS
         def initialize(options = {})
             @server   = normalize_server(options[:server])
             @username = options[:username].to_s
@@ -214,16 +133,8 @@ module NetAppShift
                 raise ArgumentError, 'Shift :username and :password are required'
             end
 
-            @script_dir = File.expand_path(options[:script_dir] || SCRIPT_DIR)
-            @python     = options[:python] || 'python3'
-            @logger     = options[:logger] || self.class.stdout_logger
-            @timeouts   = DEFAULT_TIMEOUTS.merge(options[:timeouts] || {})
-
-            @execution_name = options[:execution_name] || 'oneswap'
-            @keep_payload   = options[:keep_payload] ? true : false
-            @dry_run        = options[:dry_run] ? true : false
-
-            @checked = false
+            @logger   = options[:logger] || self.class.stdout_logger
+            @timeouts = DEFAULTS.merge(options[:timeouts] || {})
         end
 
         def self.stdout_logger
@@ -233,216 +144,66 @@ module NetAppShift
         end
 
         # ------------------------------------------------------------------ #
-        # Payload builders                                                    #
+        # Reads                                                               #
         # ------------------------------------------------------------------ #
 
-        # Build one vm_details entry for #create_blueprint.
-        #
-        # In clone_based_conversion mode the upstream blueprint builder only
-        # uses vm_details to resolve the resource group by name and the VM ids
-        # inside it (the vmSettings block is dropped entirely), so only these
-        # three keys matter. The VM must already exist in the named resource
-        # group or the Python exits.
-        #
-        # @option options :name [String] VM name exactly as vCenter reports it
-        # @option options :resource_group_name [String] pre-created resource
-        #   group this VM belongs to
-        # @option options :boot_order [Integer]
-        def self.vm_detail(options = {})
-            name = options[:name].to_s
-
-            raise ArgumentError, 'vm_detail requires :name' if name.empty?
-
-            {
-                'name'                => name,
-                'boot_order'          => options.fetch(:boot_order, 1),
-                'resource_group_name' => options[:resource_group_name].to_s
-            }
+        # Sites registered on the appliance. Cheap connectivity and credential
+        # preflight.
+        def sites
+            api_session {|sid| api_list(sid, SETUP_PORT, '/api/setup/site') }
         end
 
-        # ------------------------------------------------------------------ #
-        # Script-backed operations                                            #
-        # ------------------------------------------------------------------ #
-
-        # GET the sites registered on the appliance. Cheap connectivity and
-        # credentials preflight; the site list itself is only logged as Python
-        # repr, so read names from Result#output or the Shift UI.
-        def get_site
-            run(:get_site)
+        # Blueprints registered on the appliance.
+        def blueprints
+            api_session {|sid| api_list(sid, SETUP_PORT, '/api/setup/drplan') }
         end
 
-        # Create a blueprint (DR plan) tying pre-created resource groups to
-        # the source and destination sites. Unused by the v1 OneSwap CLI
-        # (operators create blueprints in the Shift UI) but kept for a future
-        # mode where OneSwap creates them itself.
-        #
-        # blueprint.py reads ip_type and the windows/linux service account keys
-        # with [], not .get(), so they have to be present even for a conversion
-        # where they go unused. They default to empty strings here.
-        def create_blueprint(options = {})
-            require_options!(options, :blueprint_name, :source_site_name,
-                             :destination_site_name, :vm_details)
-
-            accounts = options[:service_accounts] || {}
-
-            run(:create_blueprint,
-                'blueprint_name'        => options[:blueprint_name].to_s,
-                'source_site_name'      => options[:source_site_name].to_s,
-                'destination_site_name' => options[:destination_site_name].to_s,
-                'migration_mode'        => options.fetch(:migration_mode, CONVERSION),
-                'vm_details'            => normalize_vm_details(options[:vm_details]),
-                # Source resource name => target resource name. Only consumed
-                # by clone_based_migration; ignored for a conversion.
-                'mappings'              => stringify(options[:mappings] || {}),
-                'ip_type'               => options.fetch(:ip_type, 'dhcp').to_s,
-                'windows_loginId'       => accounts.dig(:windows, :login_id).to_s,
-                'windows_password'      => accounts.dig(:windows, :password).to_s,
-                'linux_loginId'         => accounts.dig(:linux, :login_id).to_s,
-                'linux_password'        => accounts.dig(:linux, :password).to_s)
-        end
-
-        # Run the compliance check for a blueprint and wait for the verdict.
-        # The script sleeps 20s before it starts, to let the blueprint settle.
-        def run_compliance_check(blueprint_name, migration_mode = CONVERSION)
-            run(:run_compliance_check,
-                'blueprint_name' => blueprint_name.to_s,
-                'migration_mode' => migration_mode.to_s)
-        end
-
-        # Execute the blueprint. With CONVERSION this POSTs to
-        # .../convert/execution (disks only); with MIGRATION it POSTs to
-        # .../migrate/execution. Returns as soon as Shift accepts the job --
-        # the execution id it yields is what #check_migration_status needs.
-        def trigger_migration(blueprint_name, migration_mode = CONVERSION)
-            run(:trigger_migration,
-                'blueprint_name' => blueprint_name.to_s,
-                'migration_mode' => migration_mode.to_s)
-        end
-
-        # Check/wait on the execution: the script polls the blueprint status
-        # (up to ~20 min) and then validates every job step. A result whose
-        # :status is nil or "False" means the script gave up waiting while the
-        # execution was still running -- see #wait_for_completion.
-        def check_migration_status(blueprint_name, execution_id)
-            run(:check_migration_status,
-                'blueprint_name' => blueprint_name.to_s,
-                'execution_id'   => execution_id.to_s)
-        end
-
-        # Block until the blueprint execution reaches a terminal state, by
-        # re-invoking check_migration_status as often as needed (each run
-        # waits up to ~20 min inside the Python, so this survives conversions
-        # of any length).
-        #
-        # @param timeout [Integer, nil] overall ceiling in seconds; nil or 0
-        #   waits forever (the caller decides how to surface Ctrl+C)
-        # @return [Result] the terminal check_migration_status result
-        def wait_for_completion(blueprint_name, execution_id, timeout: nil)
-            deadline = Time.now + timeout.to_f if timeout && timeout.to_f > 0
-            t0       = Time.now
-
-            loop do
-                result = check_migration_status(blueprint_name, execution_id)
-
-                return result if result.ok?
-
-                status = result[:status]
-
-                if result[:complete] || status.to_s.include?('error')
-                    # Terminal but not ok: completed-with-failed-steps or an
-                    # error status.
-                    check!(result)
-                end
-
-                waited = (Time.now - t0).round
-                @logger.info("NetApp Shift: blueprint '#{blueprint_name}' still " \
-                             "running after #{waited}s, polling again")
-
-                if deadline && Time.now >= deadline
-                    raise OperationError.new(
-                        "Timed out after #{waited}s waiting for blueprint " \
-                        "'#{blueprint_name}' execution #{execution_id}",
-                        result
-                    )
-                end
-
-                # The script itself polls for minutes; this only paces the
-                # rare quick-return cases (e.g. transient API errors).
-                sleep 10
-            end
-        end
-
-        # ------------------------------------------------------------------ #
-        # Read-only REST lookups                                              #
-        #                                                                     #
-        # The Python scripts log these objects as Python repr, which is not   #
-        # machine readable, so the reads go straight to the appliance API     #
-        # (same endpoints, ports and headers the Python modules use). If the  #
-        # submodule fork ever adds JSON-printing scripts, replace these.      #
-        # ------------------------------------------------------------------ #
-
-        # VM names covered by a blueprint, in resource-group order. This is
-        # what a blueprint execution will convert.
+        # VM names a blueprint covers, in resource-group order. This is what
+        # one execution of it will convert.
         #
         # @return [Array<String>]
         def blueprint_vm_names(blueprint_name)
             api_session do |sid|
-                blueprint = api_find_blueprint(sid, blueprint_name)
+                blueprint = find_blueprint(sid, blueprint_name)
 
                 rg_ids = Array(blueprint['protectionGroups']).map {|rg| rg['_id'] }.compact
-                groups = api_list(sid, '/api/setup/protectionGroup')
+                groups = api_list(sid, SETUP_PORT, '/api/setup/protectionGroup')
                          .select {|rg| rg_ids.include?(rg['_id']) }
 
-                names = groups.flat_map {|rg| Array(rg['vms']).map {|vm| vm['name'] } }
-                              .compact
+                names = groups.flat_map {|rg| Array(rg['vms']).map {|vm| vm['name'] } }.compact
 
                 if names.empty?
                     raise OperationError,
-                          "Blueprint '#{blueprint_name}' has no VMs in its " \
-                          'resource group(s)'
+                          "Blueprint '#{blueprint_name}' has no VMs in its resource group(s)"
                 end
 
                 names
             end
         end
 
-        # Current execution state of a blueprint, or nil if it has never run.
+        # Whether a blueprint has already run, is running, or failed -- nil if
+        # it has never run or the appliance does not list it.
         #
-        # This is what makes repeat invocations work: a blueprint that has
-        # already executed cannot be executed again until its prior executions
-        # are deleted (NetApp ships PowerShell/removeBpJobs.ps1 for that), and
-        # one execution converts every VM in the resource group anyway. So the
-        # caller checks here first and imports the existing disks instead of
-        # triggering a second time.
-        #
-        # GET :3704/api/recovery/drplan/status returns a list of
-        #   { 'drPlan' => {'_id', 'recoveryStatus'}, 'lastExecution' => {'_id', 'status'} }
-        # recoveryStatus is the same string verify_blueprint_status keys off:
-        # it contains "complete" or "error" once terminal.
-        #
-        # Note this is only an optimisation: it saves a pointless compliance
-        # check and trigger. The authoritative signal that a blueprint cannot
-        # run again is the ERSCSTEX009 error the trigger itself returns, which
-        # #parse_trigger_migration reports as :already_executed.
+        # Best effort, and only an optimisation: it saves a pointless
+        # compliance check and trigger. The reliable signal that a blueprint
+        # cannot run again is the AlreadyExecuted raised by
+        # #trigger_conversion.
         #
         # @return [Hash, nil] :status, :execution_id, :complete, :failed, :running
         def blueprint_execution_state(blueprint_name)
             api_session do |sid|
-                id       = api_find_blueprint(sid, blueprint_name)['_id']
+                id       = find_blueprint(sid, blueprint_name)['_id']
                 response = api_get(sid, RECOVERY_PORT, '/api/recovery/drplan/status')
 
                 @logger.debug("NetApp Shift: drplan/status -> #{response.inspect}")
 
-                # Bare array in the appliances seen so far, but tolerate the
-                # setup service's {'list' => [...]} envelope too.
                 entries = response.is_a?(Hash) ? Array(response['list']) : Array(response)
-
-                entry = entries.find do |e|
+                entry   = entries.find do |e|
                     e.is_a?(Hash) && e.dig('drPlan', '_id') == id
                 end
 
                 if entry.nil?
-                    @logger.debug("NetApp Shift: blueprint #{id} not present in drplan/status")
+                    @logger.debug("NetApp Shift: blueprint #{id} absent from drplan/status")
                     next nil
                 end
 
@@ -460,27 +221,44 @@ module NetAppShift
             end
         end
 
-        # ------------------------------------------------------------------ #
-        # Locating the converted disks                                        #
-        # ------------------------------------------------------------------ #
+        # Job steps of an execution. Each carries a 'description' and a
+        # 'status' (see STEP_SUCCESS / STEP_FAILED).
+        #
+        # @return [Array<Hash>]
+        def job_steps(execution_id)
+            api_session do |sid|
+                response = api_get(sid, RECOVERY_PORT,
+                                   "/api/recovery/execution/#{execution_id}/steps")
+
+                Array(response['steps'])
+            end
+        end
+
+        # Overall state of an execution, derived from its job steps. This is
+        # keyed by execution id rather than blueprint, so unlike
+        # #blueprint_execution_state it does not depend on the blueprint being
+        # listed anywhere.
+        #
+        # @return [Symbol] :complete, :failed, :running or :unknown
+        def execution_status(execution_id)
+            classify_steps(job_steps(execution_id))
+        end
 
         # Paths of the converted disks for a VM on the locally mounted source
         # NFS datastore, in disk order.
         #
         # Observed Shift naming (verified on hardware, single and multi-disk):
         # the first disk is "<vm-name>.qcow2" and each additional disk is
-        # "<vm-name>_<n>.qcow2", all directly in the datastore root next to
-        # the VM's folder. Disk order is assumed to follow the source device
-        # order (base name = first disk).
+        # "<vm-name>_<n>.qcow2", all in the datastore root next to the VM's
+        # folder. Disk order is assumed to follow the source device order.
         #
-        # @param vm_name [String]
-        # @param mount   [String]  local mount point of the datastore
-        # @param count   [Integer] number of disks the VM has (from vCenter)
+        # @param count [Integer] number of disks the VM has
         # @return [Array<String>] existing paths, first disk first
         # @raise [Error] naming every expected file that is missing
         def converted_disks(vm_name, mount, count)
-            raise ArgumentError, 'converted_disks requires a positive disk count' if
-                count.to_i < 1
+            if count.to_i < 1
+                raise ArgumentError, 'converted_disks requires a positive disk count'
+            end
 
             expected = [File.join(mount.to_s, "#{vm_name}.qcow2")]
             (1...count.to_i).each do |i|
@@ -491,122 +269,190 @@ module NetAppShift
 
             unless missing.empty?
                 raise Error,
-                      "Converted disk(s) not found for '#{vm_name}': " \
-                      "#{missing.join(', ')}. Verify the mount point and that " \
-                      'the blueprint execution completed.'
+                      "Converted disk(s) not found for '#{vm_name}': #{missing.join(', ')}. " \
+                      'Verify the mount point and that the blueprint execution completed.'
             end
 
             expected
         end
 
         # ------------------------------------------------------------------ #
-        # Plumbing                                                            #
+        # Actions                                                             #
         # ------------------------------------------------------------------ #
 
-        # Run one operation with a single execution entry.
+        # Request a compliance check for a blueprint and poll until it
+        # succeeds.
         #
-        # @return [NetAppShift::Result]
-        def run(operation, execution = {})
-            run_many(operation, [execution])
+        # @return [Hash] :task_id and the appliance's :result payload
+        # @raise [OperationError] if it fails or never settles
+        def run_compliance_check(blueprint_name, settle: nil)
+            settle = settle.nil? ? @timeouts[:compliance_settle].to_i : settle.to_i
+
+            # A blueprint needs a moment to settle before it will pass a check.
+            # Matches NetApp's own client; done before opening a session so one
+            # is not held idle.
+            if settle > 0
+                @logger.info("NetApp Shift: letting blueprint '#{blueprint_name}' " \
+                             "settle for #{settle}s before the compliance check")
+                sleep settle
+            end
+
+            api_session do |sid|
+                id = find_blueprint(sid, blueprint_name)['_id']
+
+                started = api_post(sid, SETUP_PORT,
+                                   "/api/setup/compliance/drplan/#{id}/checkrequest?async=true",
+                                   :timeout => @timeouts[:compliance_timeout])
+
+                task_id = started['taskId']
+
+                if task_id.nil?
+                    raise OperationError,
+                          "Compliance check for '#{blueprint_name}' returned no task id"
+                end
+
+                @logger.info("NetApp Shift: compliance check task #{task_id}")
+
+                poll_compliance(sid, task_id, blueprint_name)
+            end
         end
 
-        # Run one operation over several execution entries. Upstream loops the
-        # "executions" array, so batching works, but the scrapers report on the
-        # combined output -- prefer one entry per call when the ids matter.
-        def run_many(operation, executions)
-            op   = operation.to_sym
-            name = OPERATIONS[op]
+        # Execute a blueprint. With CONVERSION this converts the disks only;
+        # no VM is built on the target hypervisor.
+        #
+        # @return [String] the execution id
+        # @raise [AlreadyExecuted] if the blueprint has already converted
+        def trigger_conversion(blueprint_name, mode = CONVERSION)
+            api_session do |sid|
+                id = find_blueprint(sid, blueprint_name)['_id']
 
-            raise ArgumentError, "Unknown Shift operation: #{operation}" if name.nil?
+                payload = {
+                    'serviceAccounts' => {
+                        'common' => { 'loginId' => nil, 'password' => nil },
+                        'vms'    => []
+                    }
+                }
 
-            payload = {
-                'executions' => executions.map {|e| base_execution.merge(stringify(e)) }
-            }
+                # Note the capital P: this path is drPlan, unlike the lowercase
+                # drplan of /api/recovery/drplan/status.
+                response = api_post(sid, RECOVERY_PORT,
+                                    "/api/recovery/drPlan/#{id}/#{mode}/execution",
+                                    :body => payload)
 
-            if @dry_run
-                @logger.info("NetApp Shift: [dry-run] #{name}.json\n" \
-                             "#{JSON.pretty_generate(redact(payload))}")
+                execution_id = response['_id'] || deep_find(response, '_id')
 
-                return Result.new(op, :data => { :ok => true, :dry_run => true })
+                if execution_id.nil?
+                    raise OperationError,
+                          "Shift accepted the execution of '#{blueprint_name}' but " \
+                          'returned no execution id'
+                end
+
+                execution_id
             end
-
-            ensure_dependencies!
-
-            @logger.debug("NetApp Shift: #{name}.json\n#{JSON.pretty_generate(redact(payload))}")
-
-            output, status, timed_out, duration = with_payload(name, payload) do
-                execute("#{name}.py", @timeouts.fetch(op, 600))
-            end
-
-            result = Result.new(op,
-                                :output    => output,
-                                :errors    => error_lines(output),
-                                :data      => parse(op, output),
-                                :exit_code => status && status.exitstatus,
-                                :timed_out => timed_out,
-                                :duration  => duration)
-
-            log_result(result)
-
-            result
         end
 
-        # Raise unless the result reports success.
-        def check!(result)
-            return result if result.ok?
+        # Block until an execution reaches a terminal state.
+        #
+        # Completion is read from the execution's own job steps, so this works
+        # regardless of whether the blueprint shows up in the appliance's
+        # blueprint status list. A fresh session is opened per poll so a long
+        # conversion cannot outlive its session.
+        #
+        # @param timeout [Integer, nil] overall ceiling in seconds; nil or 0
+        #   waits indefinitely (the caller decides how to surface Ctrl+C)
+        # @return [Hash] :status and the final :steps
+        def wait_for_completion(blueprint_name, execution_id, timeout: nil, interval: nil)
+            interval = (interval || @timeouts[:status_poll_interval]).to_f
+            deadline = Time.now + timeout.to_f if timeout && timeout.to_f > 0
+            t0       = Time.now
 
-            # The scripts log root cause first and a generic trailer last
-            # ("Migration trigger failed for migration index 1"), so prefer
-            # the line carrying the HTTP status and response body.
-            reason = if result.timed_out?
-                         "timed out after #{result.duration}s"
-                     elsif result.errors.any?
-                         result.errors.find {|e| e.include?('Response code') } ||
-                             result.errors.first
-                     else
-                         'the script logged no success message'
-                     end
+            loop do
+                steps = job_steps(execution_id)
 
-            raise OperationError.new("NetApp Shift #{result.operation} failed: #{reason}", result)
-        end
+                case classify_steps(steps)
+                when :complete
+                    return { :status => 'complete', :steps => steps }
+                when :failed
+                    failed = steps.select {|s| s['status'] == STEP_FAILED }
+                                  .map {|s| s['description'] }.compact
+                    raise OperationError,
+                          "Shift execution #{execution_id} of '#{blueprint_name}' failed" \
+                          "#{failed.empty? ? '' : " at: #{failed.join(', ')}"}"
+                end
 
-        # Verify python3, the vendored scripts and their imports are usable.
-        # Memoized: it costs one interpreter start up per helper.
-        def ensure_dependencies!
-            return true if @checked
+                waited = (Time.now - t0).round
+                @logger.info("NetApp Shift: execution #{execution_id} still running " \
+                             "after #{waited}s")
 
-            unless File.directory?(@script_dir)
-                raise DependencyError,
-                      "Shift scripts not found at #{@script_dir}. The " \
-                      'shift-api-automation submodule is probably not checked ' \
-                      'out (git submodule update --init).'
+                if deadline && Time.now >= deadline
+                    raise OperationError,
+                          "Timed out after #{waited}s waiting for execution #{execution_id} " \
+                          "of blueprint '#{blueprint_name}'"
+                end
+
+                sleep interval
             end
-
-            missing = OPERATIONS.values.reject do |name|
-                File.file?(File.join(@script_dir, "#{name}.py"))
-            end
-
-            unless missing.empty?
-                raise DependencyError,
-                      "Missing Shift scripts in #{@script_dir}: " \
-                      "#{missing.map {|m| "#{m}.py" }.join(', ')}"
-            end
-
-            imports = PYTHON_MODULES.map {|mod| "import #{mod}" }.join('; ')
-
-            _stdout, stderr, status =
-                Open3.capture3(@python, '-c', imports, :chdir => @script_dir)
-
-            unless status.success?
-                raise DependencyError,
-                      "#{@python} cannot import the Shift dependencies " \
-                      "(#{PYTHON_MODULES.join(', ')}): #{stderr.strip}"
-            end
-
-            @checked = true
         end
 
         private
+
+        # Every step succeeded / any step failed / still working / no steps yet.
+        def classify_steps(steps)
+            return :unknown if steps.empty?
+
+            statuses = steps.map {|s| s['status'] }
+
+            return :failed   if statuses.include?(STEP_FAILED)
+            return :complete if statuses.all? {|s| s == STEP_SUCCESS }
+
+            :running
+        end
+
+        def poll_compliance(session_id, task_id, blueprint_name)
+            limit    = @timeouts[:compliance_poll_limit].to_i
+            interval = @timeouts[:compliance_poll_interval].to_f
+
+            limit.times do
+                # The task id goes in both the path and the query string; that
+                # is what the appliance expects, odd as it reads.
+                response = api_post(session_id, SETUP_PORT,
+                                    "/api/setup/compliance/drplan/#{task_id}" \
+                                    "/checkrequest?taskId=#{task_id}",
+                                    :timeout => @timeouts[:compliance_timeout])
+
+                status = response['status'].to_s
+
+                return { :task_id => task_id, :result => response['result'] } if
+                    status == 'succeeded'
+
+                if ['failed', 'error'].include?(status)
+                    raise OperationError,
+                          "Compliance check for '#{blueprint_name}' #{status}: " \
+                          "#{response['result'].inspect}"
+                end
+
+                @logger.debug("NetApp Shift: compliance #{task_id} is #{status}")
+                sleep interval
+            end
+
+            raise OperationError,
+                  "Compliance check for '#{blueprint_name}' did not finish within " \
+                  "#{(limit * interval).round}s"
+        end
+
+        def find_blueprint(session_id, blueprint_name)
+            all       = api_list(session_id, SETUP_PORT, '/api/setup/drplan')
+            blueprint = all.find {|bp| bp['name'] == blueprint_name }
+
+            if blueprint.nil?
+                known = all.map {|bp| bp['name'] }.compact
+                raise OperationError,
+                      "Blueprint '#{blueprint_name}' not found on #{@server}. " \
+                      "Available blueprints: #{known.empty? ? '(none)' : known.join(', ')}"
+            end
+
+            blueprint
+        end
 
         # Shift's URI is built as "<server>:<port>/api/...", so the value has
         # to carry a scheme and nothing else.
@@ -619,80 +465,34 @@ module NetAppShift
 
             if value.match?(%r{\A\w+://[^/]+:\d+\z})
                 raise ArgumentError,
-                      "Shift :server must not include a port (#{value}); the " \
-                      'scripts append 3698/3700/3704 themselves'
+                      "Shift :server must not include a port (#{value}); the service " \
+                      'port is chosen per request'
             end
 
             value
         end
 
-        def base_execution
-            {
-                'execution_name'  => @execution_name,
-                'shift_server_ip' => @server,
-                'shift_username'  => @username,
-                'shift_password'  => @password
-            }
-        end
+        # ---------------------------- transport --------------------------- #
 
-        def normalize_vm_details(vm_details)
-            details = Array(vm_details).map {|vm| stringify(vm) }
-
-            raise ArgumentError, ':vm_details must not be empty' if details.empty?
-
-            details
-        end
-
-        def require_options!(options, *keys)
-            missing = keys.reject do |key|
-                value = options[key]
-                value.respond_to?(:empty?) ? !value.empty? : !value.nil?
-            end
-
-            return if missing.empty?
-
-            raise ArgumentError, "Missing required option(s): #{missing.join(', ')}"
-        end
-
-        # Deep convert symbol keys so callers can use either style.
-        def stringify(value)
-            case value
-            when Hash
-                value.each_with_object({}) {|(k, v), acc| acc[k.to_s] = stringify(v) }
-            when Array
-                value.map {|v| stringify(v) }
-            else
-                value
-            end
-        end
-
-        def redact(value)
-            case value
-            when Hash
-                value.each_with_object({}) do |(key, val), acc|
-                    acc[key] = key.to_s.match?(/password|passwd|secret/i) ? '[redacted]' : redact(val)
-                end
-            when Array
-                value.map {|v| redact(v) }
-            else
-                value
-            end
-        end
-
-        # -------------------------- REST plumbing ------------------------- #
-
-        # Open a session, yield its id, always end the session.
+        # Open a session, yield its id, end the session. Re-entrant: nested
+        # calls reuse the open session rather than opening another.
         def api_session
+            return yield(@session_id) if @session_id
+
             response = api_request(Net::HTTP::Post, SESSION_PORT, '/api/tenant/session',
-                                   :body => { 'loginId' => @username, 'password' => @password })
+                                   :body => { 'loginId' => @username,
+                                              'password' => @password })
 
             sid = response.dig('session', '_id') || deep_find(response, '_id')
 
             raise OperationError, 'Shift session: no session id in response' if sid.nil?
 
+            @session_id = sid
+
             begin
                 yield sid
             ensure
+                @session_id = nil
                 begin
                     api_request(Net::HTTP::Post, SESSION_PORT, '/api/tenant/session/end',
                                 :body => { 'sessionId' => sid }, :session => sid)
@@ -702,40 +502,27 @@ module NetAppShift
             end
         end
 
+        def api_get(session_id, port, path, timeout: nil)
+            api_request(Net::HTTP::Get, port, path,
+                        :session => session_id, :timeout => timeout)
+        end
+
+        def api_post(session_id, port, path, body: nil, timeout: nil)
+            api_request(Net::HTTP::Post, port, path,
+                        :session => session_id, :body => body, :timeout => timeout)
+        end
+
         # GET a paged setup collection and return its 'list'.
-        def api_list(session_id, path)
-            response = api_request(Net::HTTP::Get, SETUP_PORT, path, :session => session_id)
-
-            Array(response['list'])
+        def api_list(session_id, port, path)
+            Array(api_get(session_id, port, path)['list'])
         end
 
-        # GET a path on any service port, returning the parsed body as-is.
-        # The recovery endpoints answer with a bare array rather than the
-        # setup service's {'list' => [...]} envelope.
-        def api_get(session_id, port, path)
-            api_request(Net::HTTP::Get, port, path, :session => session_id)
-        end
-
-        def api_find_blueprint(session_id, blueprint_name)
-            blueprints = api_list(session_id, '/api/setup/drplan')
-            blueprint  = blueprints.find {|bp| bp['name'] == blueprint_name }
-
-            if blueprint.nil?
-                known = blueprints.map {|bp| bp['name'] }.compact
-                raise OperationError,
-                      "Blueprint '#{blueprint_name}' not found on #{@server}. " \
-                      "Available blueprints: #{known.empty? ? '(none)' : known.join(', ')}"
-            end
-
-            blueprint
-        end
-
-        # One JSON request against the appliance. TLS verification is off to
-        # match the Python (verify=False) -- Shift appliances ship self-signed
-        # certificates.
-        def api_request(method_class, port, path, body: nil, session: nil, timeout: 30)
-            uri  = URI.parse("#{@server}:#{port}#{path}")
-            http = Net::HTTP.new(uri.host, uri.port)
+        # One JSON request. TLS verification is disabled to match NetApp's own
+        # client -- Shift appliances ship self-signed certificates.
+        def api_request(method_class, port, path, body: nil, session: nil, timeout: nil)
+            timeout = (timeout || @timeouts[:http_timeout]).to_i
+            uri     = URI.parse("#{@server}:#{port}#{path}")
+            http    = Net::HTTP.new(uri.host, uri.port)
 
             http.use_ssl      = uri.scheme == 'https'
             http.verify_mode  = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
@@ -747,13 +534,11 @@ module NetAppShift
             request['netapp-sie-sessionid'] = session if session
             request.body = JSON.generate(body) if body
 
+            @logger.debug("NetApp Shift: #{method_class::METHOD} #{uri}")
+
             response = http.request(request)
 
-            unless response.is_a?(Net::HTTPSuccess)
-                raise OperationError,
-                      "Shift API #{path} returned #{response.code}: " \
-                      "#{response.body.to_s[0, 200]}"
-            end
+            raise_api_error(response, path) unless response.is_a?(Net::HTTPSuccess)
 
             response.body.to_s.empty? ? {} : JSON.parse(response.body)
         rescue JSON::ParserError => e
@@ -762,8 +547,36 @@ module NetAppShift
             raise OperationError, "Shift API #{path} failed: #{e.class}: #{e.message}"
         end
 
-        # First value for key anywhere in a nested structure (the session
-        # response nests the id; mirrors the Python's parse_json search).
+        # Turn an error response into the most useful exception available.
+        # The appliance answers with
+        #   {"level":"error","message":"...","errors":[{"code":"...","message":"..."}]}
+        # so the readable message is pulled out rather than dumping the blob.
+        def raise_api_error(response, path)
+            parsed = begin
+                JSON.parse(response.body.to_s)
+            rescue JSON::ParserError
+                nil
+            end
+
+            detail = parsed.is_a?(Hash) ? (Array(parsed['errors']).first || parsed) : nil
+            code    = detail.is_a?(Hash) ? detail['code'] : nil
+            message = (detail.is_a?(Hash) && detail['message']) ||
+                      response.body.to_s[0, 300]
+
+            if code == ERR_ALREADY_EXECUTED || message.to_s.match?(/No further execution is allowed/i)
+                raise AlreadyExecuted.new(message.to_s,
+                                          :code => code,
+                                          :http_status => response.code.to_i)
+            end
+
+            raise OperationError.new(
+                "Shift API #{path} returned #{response.code}: #{message}",
+                :code => code, :http_status => response.code.to_i
+            )
+        end
+
+        # First value for key anywhere in a nested structure; the session
+        # response nests the id.
         def deep_find(obj, key)
             case obj
             when Hash
@@ -781,225 +594,6 @@ module NetAppShift
                 end
                 nil
             end
-        end
-
-        # ------------------------ script plumbing ------------------------- #
-
-        # Render the payload to the fixed path the script reads, run the block,
-        # then put the original file back.
-        #
-        # The path comes from Config.yml and cannot be overridden per run, so
-        # concurrent helpers would clobber each other -- hence the lock. The
-        # file holds plaintext credentials while it exists, so it is written
-        # 0600 and its previous mode is restored along with its contents.
-        def with_payload(name, payload)
-            path = File.join(@script_dir, "#{name}.json")
-
-            lock(name) do
-                original = File.exist?(path) ? File.binread(path) : nil
-                mode     = File.exist?(path) ? File.stat(path).mode : nil
-
-                begin
-                    FileUtils.touch(path)
-                    File.chmod(0o600, path)
-                    File.write(path, JSON.pretty_generate(payload))
-
-                    yield path
-                ensure
-                    if @keep_payload
-                        @logger.warn("NetApp Shift: leaving #{path} in place; " \
-                                     'it contains plaintext credentials')
-                    elsif original
-                        File.write(path, original)
-                        File.chmod(mode, path) if mode
-                    else
-                        FileUtils.rm_f(path)
-                    end
-                end
-            end
-        end
-
-        # Serialize helpers that share a script directory. The lock lives in
-        # tmp so it never shows up as untracked noise in the submodule.
-        def lock(name)
-            key  = Digest::SHA256.hexdigest("#{@script_dir}/#{name}")[0, 16]
-            path = File.join(Dir.tmpdir, "oneswap-shift-#{key}.lock")
-
-            File.open(path, File::RDWR | File::CREAT, 0o600) do |file|
-                unless file.flock(File::LOCK_EX | File::LOCK_NB)
-                    @logger.info("NetApp Shift: waiting for #{name} payload lock")
-                    file.flock(File::LOCK_EX)
-                end
-
-                begin
-                    yield
-                ensure
-                    file.flock(File::LOCK_UN)
-                end
-            end
-        end
-
-        # Run a script from the Python directory, streaming its output to the
-        # log and enforcing a timeout.
-        #
-        # CWD matters twice over: the scripts import siblings (api_wrapper,
-        # utils, conftest) and log_config creates its logs/ tree relative to
-        # the working directory.
-        #
-        # Python's logging writes to stderr, so both streams are captured and
-        # merged; get_site.py attaches a second StreamHandler and so logs
-        # every line twice.
-        #
-        # @return [Array] [output, status, timed_out, duration]
-        def execute(script, timeout)
-            @logger.info("NetApp Shift: running #{script} (timeout #{timeout}s)")
-
-            buffer    = +''
-            mutex     = Mutex.new
-            timed_out = false
-            status    = nil
-            t0        = Time.now
-
-            Open3.popen3(@python, script,
-                         :chdir => @script_dir,
-                         :pgroup => true) do |stdin, out, err, wait_thr|
-                stdin.close
-
-                readers = [out, err].map do |io|
-                    Thread.new do
-                        io.each_line do |line|
-                            mutex.synchronize { buffer << line }
-                            @logger.debug("[shift] #{line.chomp}")
-                        end
-                    rescue IOError
-                        nil
-                    end
-                end
-
-                unless wait_thr.join(timeout)
-                    timed_out = true
-                    @logger.error("NetApp Shift: #{script} exceeded #{timeout}s, terminating")
-                    kill_process_group(wait_thr.pid)
-                end
-
-                status = wait_thr.value
-
-                readers.each {|thread| thread.join(5) }
-                readers.each(&:kill)
-            end
-
-            [buffer, status, timed_out, (Time.now - t0).round(2)]
-        end
-
-        # Sends TERM then KILL to the process group led by pid.
-        def kill_process_group(pid)
-            Process.kill('TERM', -pid)
-            sleep 5
-            Process.kill('KILL', -pid)
-        rescue Errno::ESRCH, Errno::EPERM
-            nil
-        end
-
-        def log_result(result)
-            if result.ok?
-                @logger.info("NetApp Shift: #{result}")
-            else
-                @logger.error("NetApp Shift: #{result}")
-                result.errors.each {|line| @logger.error("[shift] #{line}") }
-            end
-        end
-
-        LOG_LINE = /^[\d\-]+ [\d:,]+ - \S+ - (?<level>\w+) - (?<message>.*)$/.freeze
-
-        def error_lines(output)
-            output.each_line.filter_map do |line|
-                match = LOG_LINE.match(line.chomp)
-                next unless match && match[:level] == 'ERROR'
-
-                match[:message]
-            end.uniq
-        end
-
-        # ------------------------------------------------------------------ #
-        # Output scraping                                                     #
-        #                                                                     #
-        # The strings below are the log messages the upstream scripts emit on #
-        # success. They are the only machine readable signal available, so    #
-        # they need re-checking whenever the submodule is bumped.             #
-        # ------------------------------------------------------------------ #
-
-        def parse(operation, output)
-            case operation
-            when :get_site               then parse_get_site(output)
-            when :create_blueprint       then parse_create_blueprint(output)
-            when :run_compliance_check   then parse_compliance(output)
-            when :trigger_migration      then parse_trigger_migration(output)
-            when :check_migration_status then parse_migration_status(output)
-            else { :ok => false }
-            end
-        end
-
-        def parse_get_site(output)
-            { :ok => output.include?('Site details fetched successfully') }
-        end
-
-        def parse_create_blueprint(output)
-            id = output[/Blueprint created with id:\s*(\S+)/, 1]
-
-            {
-                :ok           => !id.nil?,
-                :blueprint_id => id,
-                :verified     => output.include?('Verified blueprint details:')
-            }
-        end
-
-        def parse_compliance(output)
-            task_id = output[/Compliance check initiated with task id:\s*(\S+)/, 1]
-            result  = output[/Compliance check passed with result:\s*(.*)$/, 1]
-
-            {
-                :ok                 => !task_id.nil? && !result.nil?,
-                :compliance_task_id => task_id,
-                :compliance_result  => result
-            }
-        end
-
-        # Shift refuses to execute a blueprint that already converted
-        # successfully, with ERSCSTEX009 "No further execution is allowed".
-        # That is not a failure for OneSwap -- the disks it needs are already
-        # on the datastore -- so it is reported separately from :ok.
-        ALREADY_EXECUTED = /ERSCSTEX009|No further execution is allowed/i.freeze
-
-        def parse_trigger_migration(output)
-            id = output[/Migration triggered for blueprint .* with execution id:\s*(\S+)/, 1]
-
-            {
-                :ok               => !id.nil?,
-                :execution_id     => id,
-                :already_executed => id.nil? && output.match?(ALREADY_EXECUTED)
-            }
-        end
-
-        def parse_migration_status(output)
-            status = output[/Status of Blueprint is (\S+) for blueprint/, 1]
-            jobs   = output.include?('Job steps successfully completed for execution id')
-
-            # verify_blueprint_status returns a real status only once it
-            # contains "complete" or "error"; when its ~20 min polling window
-            # runs out first it returns Python False, which the script logs as
-            # the literal status "False" -- that means "still running", not
-            # "failed". #wait_for_completion keys off :running to re-invoke.
-            complete = status.to_s.include?('complete')
-            running  = status.nil? || status == 'False'
-
-            {
-                :ok           => complete && jobs,
-                :status       => status,
-                :complete     => complete,
-                :running      => running,
-                :jobs_ok      => jobs,
-                :failed_steps => output.scan(/Job step (.*) is not successful/).flatten.uniq
-            }
         end
 
     end

--- a/netapp_shift_helper.rb
+++ b/netapp_shift_helper.rb
@@ -1,0 +1,930 @@
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2026, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'logger'
+require 'net/http'
+require 'open3'
+require 'openssl'
+require 'tmpdir'
+require 'uri'
+
+# NetApp Shift integration for OneSwap.
+#
+# This is a thin wrapper around the vendored NetApp "shift-api-automation"
+# Python scripts (scripts/shift-api-automation/Python, a git submodule).
+#
+# The upstream scripts are not a library: each one reads a *fixed* JSON file
+# next to itself (the path comes from Config.yml via conftest.py), talks to the
+# Shift appliance, and reports what happened by *logging* to stderr. There is
+# no structured output and no meaningful exit code -- the top-level scripts
+# swallow exceptions and still exit 0.
+#
+# So the wrapper does three things for each operation:
+#
+#   1. Build the "executions" JSON payload and write it to the path the script
+#      expects, restoring the original file afterwards (the payload holds
+#      plaintext credentials, so it is chmod 0600 while it exists).
+#   2. Run the script with CWD set to the Python directory (its imports and its
+#      logs/ directory are both relative to it).
+#   3. Scrape the captured output for the identifiers and statuses the script
+#      logged, and hand them back as a NetAppShift::Result.
+#
+# The Shift workflow OneSwap drives: the operator pre-creates the source site,
+# destination site, resource group(s) and blueprint in the Shift UI. OneSwap
+# then runs the compliance check, triggers the blueprint execution in
+# "clone_based_conversion" mode (which converts every VM in the blueprint's
+# resource groups in parallel) and waits for it to finish. The converted disks
+# appear on the source NFS datastore next to each VM's folder:
+#
+#   <mount>/<vm-name>.qcow2         first disk
+#   <mount>/<vm-name>_1.qcow2       second disk
+#   <mount>/<vm-name>_2.qcow2       third disk, ...
+#
+#   shift = NetAppShift::Helper.new(
+#       :server   => 'https://10.0.0.5',
+#       :username => 'admin',
+#       :password => 'secret',
+#       :logger   => @logger
+#   )
+#
+#   shift.blueprint_vm_names('bp1')                 # => ['web01', 'db01']
+#   shift.check!(shift.run_compliance_check('bp1'))
+#   trigger = shift.check!(shift.trigger_migration('bp1'))
+#   shift.wait_for_completion('bp1', trigger[:execution_id])
+#   shift.converted_disks('web01', '/mnt/shift', 2)
+#   # => ['/mnt/shift/web01.qcow2', '/mnt/shift/web01_1.qcow2']
+#
+module NetAppShift
+
+    class Error < StandardError; end
+
+    # Raised when python3 or the vendored scripts/modules are not usable.
+    class DependencyError < Error; end
+
+    # Raised by check!/wait_for_completion/API reads when an operation did not
+    # report success.
+    class OperationError < Error
+
+        attr_reader :result
+
+        def initialize(message, result = nil)
+            super(message)
+            @result = result
+        end
+
+    end
+
+    # Outcome of a single script invocation.
+    class Result
+
+        attr_reader :operation, :output, :errors, :data, :exit_code, :duration
+
+        def initialize(operation, opts = {})
+            @operation = operation
+            @output    = opts[:output].to_s
+            @errors    = opts[:errors] || []
+            @data      = opts[:data] || {}
+            @exit_code = opts[:exit_code]
+            @duration  = opts[:duration]
+            @timed_out = opts[:timed_out] ? true : false
+        end
+
+        def timed_out?
+            @timed_out
+        end
+
+        # True when the script logged the messages that mean "this worked".
+        # Exit codes are useless here: the upstream scripts catch everything
+        # and still exit 0.
+        def ok?
+            !timed_out? && @data[:ok] == true
+        end
+
+        def [](key)
+            @data[key.to_sym]
+        end
+
+        def to_h
+            @data.merge(
+                :operation => @operation,
+                :ok        => ok?,
+                :timed_out => timed_out?,
+                :exit_code => @exit_code,
+                :duration  => @duration,
+                :errors    => @errors
+            )
+        end
+
+        def to_s
+            "#{@operation}: #{ok? ? 'ok' : 'failed'} (#{@duration}s)"
+        end
+
+    end
+
+    # Wrapper around the vendored shift-api-automation Python scripts, plus a
+    # minimal read-only REST client for the lookups the scripts cannot express
+    # (they log Python repr, not JSON).
+    class Helper
+
+        # Vendored submodule, relative to this file.
+        SCRIPT_DIR = File.join(__dir__, 'scripts', 'shift-api-automation', 'Python')
+
+        # Shift workflow types. "clone_based_conversion" is the disk-only
+        # workflow (POST .../convert/execution) OneSwap wants: it converts the
+        # VMDKs on the ONTAP volume without building a VM on the target
+        # hypervisor. "clone_based_migration" (POST .../migrate/execution)
+        # additionally creates and configures the target VM.
+        CONVERSION = 'clone_based_conversion'.freeze
+        MIGRATION  = 'clone_based_migration'.freeze
+
+        # Appliance service ports, matching the Python API modules: the tenant
+        # session service and the setup service (sites/resource groups/plans).
+        SESSION_PORT = 3698
+        SETUP_PORT   = 3700
+
+        # operation => basename shared by the script and its JSON payload.
+        # The payload path is fixed by Config.yml, so it cannot be overridden
+        # per run; see #with_payload for how that is handled.
+        OPERATIONS = {
+            :get_site               => 'get_site',
+            :create_blueprint       => 'create_blueprint',
+            :run_compliance_check   => 'run_compliance_check',
+            :trigger_migration      => 'trigger_migration',
+            :check_migration_status => 'check_migration_status'
+        }.freeze
+
+        # check_migration_status polls in-process: verify_blueprint_status
+        # loops 40x with a 30s sleep (~20 min) before giving up. The wrapper
+        # ceiling sits above that so it never kills a healthy run;
+        # #wait_for_completion handles executions that outlast the script's
+        # own polling window.
+        DEFAULT_TIMEOUTS = {
+            :get_site               => 120,
+            :create_blueprint       => 600,
+            :run_compliance_check   => 300,
+            :trigger_migration      => 600,
+            :check_migration_status => 2700
+        }.freeze
+
+        # trigger_migration.py imports utils.db_utils at module scope, which
+        # imports pymongo, even though the flow never touches Mongo. It still
+        # has to be installed.
+        PYTHON_MODULES = ['requests', 'envyaml', 'pymongo'].freeze
+
+        attr_reader :logger, :script_dir, :server
+
+        # @param options [Hash]
+        # @option options :server     [String] Shift appliance base URL, scheme
+        #   and host only. Ports (3698/3700/3704) are appended per service.
+        # @option options :username   [String] Shift login
+        # @option options :password   [String] Shift password
+        # @option options :script_dir [String] override the vendored Python dir
+        # @option options :python     [String] interpreter, default "python3"
+        # @option options :logger     [Logger]
+        # @option options :timeouts   [Hash] per operation overrides, seconds
+        # @option options :execution_name [String] label recorded in payloads
+        # @option options :keep_payload [Boolean] leave the rendered JSON on
+        #   disk after the run (debugging only -- it contains passwords)
+        # @option options :dry_run    [Boolean] build and log payloads without
+        #   invoking Python
+        def initialize(options = {})
+            @server   = normalize_server(options[:server])
+            @username = options[:username].to_s
+            @password = options[:password].to_s
+
+            if @username.empty? || @password.empty?
+                raise ArgumentError, 'Shift :username and :password are required'
+            end
+
+            @script_dir = File.expand_path(options[:script_dir] || SCRIPT_DIR)
+            @python     = options[:python] || 'python3'
+            @logger     = options[:logger] || self.class.stdout_logger
+            @timeouts   = DEFAULT_TIMEOUTS.merge(options[:timeouts] || {})
+
+            @execution_name = options[:execution_name] || 'oneswap'
+            @keep_payload   = options[:keep_payload] ? true : false
+            @dry_run        = options[:dry_run] ? true : false
+
+            @checked = false
+        end
+
+        def self.stdout_logger
+            logger = Logger.new(STDOUT)
+            logger.level = Logger::INFO
+            logger
+        end
+
+        # ------------------------------------------------------------------ #
+        # Payload builders                                                    #
+        # ------------------------------------------------------------------ #
+
+        # Build one vm_details entry for #create_blueprint.
+        #
+        # In clone_based_conversion mode the upstream blueprint builder only
+        # uses vm_details to resolve the resource group by name and the VM ids
+        # inside it (the vmSettings block is dropped entirely), so only these
+        # three keys matter. The VM must already exist in the named resource
+        # group or the Python exits.
+        #
+        # @option options :name [String] VM name exactly as vCenter reports it
+        # @option options :resource_group_name [String] pre-created resource
+        #   group this VM belongs to
+        # @option options :boot_order [Integer]
+        def self.vm_detail(options = {})
+            name = options[:name].to_s
+
+            raise ArgumentError, 'vm_detail requires :name' if name.empty?
+
+            {
+                'name'                => name,
+                'boot_order'          => options.fetch(:boot_order, 1),
+                'resource_group_name' => options[:resource_group_name].to_s
+            }
+        end
+
+        # ------------------------------------------------------------------ #
+        # Script-backed operations                                            #
+        # ------------------------------------------------------------------ #
+
+        # GET the sites registered on the appliance. Cheap connectivity and
+        # credentials preflight; the site list itself is only logged as Python
+        # repr, so read names from Result#output or the Shift UI.
+        def get_site
+            run(:get_site)
+        end
+
+        # Create a blueprint (DR plan) tying pre-created resource groups to
+        # the source and destination sites. Unused by the v1 OneSwap CLI
+        # (operators create blueprints in the Shift UI) but kept for a future
+        # mode where OneSwap creates them itself.
+        #
+        # blueprint.py reads ip_type and the windows/linux service account keys
+        # with [], not .get(), so they have to be present even for a conversion
+        # where they go unused. They default to empty strings here.
+        def create_blueprint(options = {})
+            require_options!(options, :blueprint_name, :source_site_name,
+                             :destination_site_name, :vm_details)
+
+            accounts = options[:service_accounts] || {}
+
+            run(:create_blueprint,
+                'blueprint_name'        => options[:blueprint_name].to_s,
+                'source_site_name'      => options[:source_site_name].to_s,
+                'destination_site_name' => options[:destination_site_name].to_s,
+                'migration_mode'        => options.fetch(:migration_mode, CONVERSION),
+                'vm_details'            => normalize_vm_details(options[:vm_details]),
+                # Source resource name => target resource name. Only consumed
+                # by clone_based_migration; ignored for a conversion.
+                'mappings'              => stringify(options[:mappings] || {}),
+                'ip_type'               => options.fetch(:ip_type, 'dhcp').to_s,
+                'windows_loginId'       => accounts.dig(:windows, :login_id).to_s,
+                'windows_password'      => accounts.dig(:windows, :password).to_s,
+                'linux_loginId'         => accounts.dig(:linux, :login_id).to_s,
+                'linux_password'        => accounts.dig(:linux, :password).to_s)
+        end
+
+        # Run the compliance check for a blueprint and wait for the verdict.
+        # The script sleeps 20s before it starts, to let the blueprint settle.
+        def run_compliance_check(blueprint_name, migration_mode = CONVERSION)
+            run(:run_compliance_check,
+                'blueprint_name' => blueprint_name.to_s,
+                'migration_mode' => migration_mode.to_s)
+        end
+
+        # Execute the blueprint. With CONVERSION this POSTs to
+        # .../convert/execution (disks only); with MIGRATION it POSTs to
+        # .../migrate/execution. Returns as soon as Shift accepts the job --
+        # the execution id it yields is what #check_migration_status needs.
+        def trigger_migration(blueprint_name, migration_mode = CONVERSION)
+            run(:trigger_migration,
+                'blueprint_name' => blueprint_name.to_s,
+                'migration_mode' => migration_mode.to_s)
+        end
+
+        # Check/wait on the execution: the script polls the blueprint status
+        # (up to ~20 min) and then validates every job step. A result whose
+        # :status is nil or "False" means the script gave up waiting while the
+        # execution was still running -- see #wait_for_completion.
+        def check_migration_status(blueprint_name, execution_id)
+            run(:check_migration_status,
+                'blueprint_name' => blueprint_name.to_s,
+                'execution_id'   => execution_id.to_s)
+        end
+
+        # Block until the blueprint execution reaches a terminal state, by
+        # re-invoking check_migration_status as often as needed (each run
+        # waits up to ~20 min inside the Python, so this survives conversions
+        # of any length).
+        #
+        # @param timeout [Integer, nil] overall ceiling in seconds; nil or 0
+        #   waits forever (the caller decides how to surface Ctrl+C)
+        # @return [Result] the terminal check_migration_status result
+        def wait_for_completion(blueprint_name, execution_id, timeout: nil)
+            deadline = Time.now + timeout.to_f if timeout && timeout.to_f > 0
+            t0       = Time.now
+
+            loop do
+                result = check_migration_status(blueprint_name, execution_id)
+
+                return result if result.ok?
+
+                status = result[:status]
+
+                if result[:complete] || status.to_s.include?('error')
+                    # Terminal but not ok: completed-with-failed-steps or an
+                    # error status.
+                    check!(result)
+                end
+
+                waited = (Time.now - t0).round
+                @logger.info("NetApp Shift: blueprint '#{blueprint_name}' still " \
+                             "running after #{waited}s, polling again")
+
+                if deadline && Time.now >= deadline
+                    raise OperationError.new(
+                        "Timed out after #{waited}s waiting for blueprint " \
+                        "'#{blueprint_name}' execution #{execution_id}",
+                        result
+                    )
+                end
+
+                # The script itself polls for minutes; this only paces the
+                # rare quick-return cases (e.g. transient API errors).
+                sleep 10
+            end
+        end
+
+        # ------------------------------------------------------------------ #
+        # Read-only REST lookups                                              #
+        #                                                                     #
+        # The Python scripts log these objects as Python repr, which is not   #
+        # machine readable, so the reads go straight to the appliance API     #
+        # (same endpoints, ports and headers the Python modules use). If the  #
+        # submodule fork ever adds JSON-printing scripts, replace these.      #
+        # ------------------------------------------------------------------ #
+
+        # VM names covered by a blueprint, in resource-group order. This is
+        # what a blueprint execution will convert.
+        #
+        # @return [Array<String>]
+        def blueprint_vm_names(blueprint_name)
+            api_session do |sid|
+                blueprint = api_find_blueprint(sid, blueprint_name)
+
+                rg_ids = Array(blueprint['protectionGroups']).map {|rg| rg['_id'] }.compact
+                groups = api_list(sid, '/api/setup/protectionGroup')
+                         .select {|rg| rg_ids.include?(rg['_id']) }
+
+                names = groups.flat_map {|rg| Array(rg['vms']).map {|vm| vm['name'] } }
+                              .compact
+
+                if names.empty?
+                    raise OperationError,
+                          "Blueprint '#{blueprint_name}' has no VMs in its " \
+                          'resource group(s)'
+                end
+
+                names
+            end
+        end
+
+        # ------------------------------------------------------------------ #
+        # Locating the converted disks                                        #
+        # ------------------------------------------------------------------ #
+
+        # Paths of the converted disks for a VM on the locally mounted source
+        # NFS datastore, in disk order.
+        #
+        # Observed Shift naming (verified on hardware, single and multi-disk):
+        # the first disk is "<vm-name>.qcow2" and each additional disk is
+        # "<vm-name>_<n>.qcow2", all directly in the datastore root next to
+        # the VM's folder. Disk order is assumed to follow the source device
+        # order (base name = first disk).
+        #
+        # @param vm_name [String]
+        # @param mount   [String]  local mount point of the datastore
+        # @param count   [Integer] number of disks the VM has (from vCenter)
+        # @return [Array<String>] existing paths, first disk first
+        # @raise [Error] naming every expected file that is missing
+        def converted_disks(vm_name, mount, count)
+            raise ArgumentError, 'converted_disks requires a positive disk count' if
+                count.to_i < 1
+
+            expected = [File.join(mount.to_s, "#{vm_name}.qcow2")]
+            (1...count.to_i).each do |i|
+                expected << File.join(mount.to_s, "#{vm_name}_#{i}.qcow2")
+            end
+
+            missing = expected.reject {|path| File.file?(path) }
+
+            unless missing.empty?
+                raise Error,
+                      "Converted disk(s) not found for '#{vm_name}': " \
+                      "#{missing.join(', ')}. Verify the mount point and that " \
+                      'the blueprint execution completed.'
+            end
+
+            expected
+        end
+
+        # ------------------------------------------------------------------ #
+        # Plumbing                                                            #
+        # ------------------------------------------------------------------ #
+
+        # Run one operation with a single execution entry.
+        #
+        # @return [NetAppShift::Result]
+        def run(operation, execution = {})
+            run_many(operation, [execution])
+        end
+
+        # Run one operation over several execution entries. Upstream loops the
+        # "executions" array, so batching works, but the scrapers report on the
+        # combined output -- prefer one entry per call when the ids matter.
+        def run_many(operation, executions)
+            op   = operation.to_sym
+            name = OPERATIONS[op]
+
+            raise ArgumentError, "Unknown Shift operation: #{operation}" if name.nil?
+
+            payload = {
+                'executions' => executions.map {|e| base_execution.merge(stringify(e)) }
+            }
+
+            if @dry_run
+                @logger.info("NetApp Shift: [dry-run] #{name}.json\n" \
+                             "#{JSON.pretty_generate(redact(payload))}")
+
+                return Result.new(op, :data => { :ok => true, :dry_run => true })
+            end
+
+            ensure_dependencies!
+
+            @logger.debug("NetApp Shift: #{name}.json\n#{JSON.pretty_generate(redact(payload))}")
+
+            output, status, timed_out, duration = with_payload(name, payload) do
+                execute("#{name}.py", @timeouts.fetch(op, 600))
+            end
+
+            result = Result.new(op,
+                                :output    => output,
+                                :errors    => error_lines(output),
+                                :data      => parse(op, output),
+                                :exit_code => status && status.exitstatus,
+                                :timed_out => timed_out,
+                                :duration  => duration)
+
+            log_result(result)
+
+            result
+        end
+
+        # Raise unless the result reports success.
+        def check!(result)
+            return result if result.ok?
+
+            reason = if result.timed_out?
+                         "timed out after #{result.duration}s"
+                     elsif result.errors.any?
+                         result.errors.last
+                     else
+                         'the script logged no success message'
+                     end
+
+            raise OperationError.new("NetApp Shift #{result.operation} failed: #{reason}", result)
+        end
+
+        # Verify python3, the vendored scripts and their imports are usable.
+        # Memoized: it costs one interpreter start up per helper.
+        def ensure_dependencies!
+            return true if @checked
+
+            unless File.directory?(@script_dir)
+                raise DependencyError,
+                      "Shift scripts not found at #{@script_dir}. The " \
+                      'shift-api-automation submodule is probably not checked ' \
+                      'out (git submodule update --init).'
+            end
+
+            missing = OPERATIONS.values.reject do |name|
+                File.file?(File.join(@script_dir, "#{name}.py"))
+            end
+
+            unless missing.empty?
+                raise DependencyError,
+                      "Missing Shift scripts in #{@script_dir}: " \
+                      "#{missing.map {|m| "#{m}.py" }.join(', ')}"
+            end
+
+            imports = PYTHON_MODULES.map {|mod| "import #{mod}" }.join('; ')
+
+            _stdout, stderr, status =
+                Open3.capture3(@python, '-c', imports, :chdir => @script_dir)
+
+            unless status.success?
+                raise DependencyError,
+                      "#{@python} cannot import the Shift dependencies " \
+                      "(#{PYTHON_MODULES.join(', ')}): #{stderr.strip}"
+            end
+
+            @checked = true
+        end
+
+        private
+
+        # Shift's URI is built as "<server>:<port>/api/...", so the value has
+        # to carry a scheme and nothing else.
+        def normalize_server(server)
+            value = server.to_s.strip.sub(%r{/+\z}, '')
+
+            raise ArgumentError, 'Shift :server is required' if value.empty?
+
+            value = "https://#{value}" unless value.match?(%r{\A\w+://})
+
+            if value.match?(%r{\A\w+://[^/]+:\d+\z})
+                raise ArgumentError,
+                      "Shift :server must not include a port (#{value}); the " \
+                      'scripts append 3698/3700/3704 themselves'
+            end
+
+            value
+        end
+
+        def base_execution
+            {
+                'execution_name'  => @execution_name,
+                'shift_server_ip' => @server,
+                'shift_username'  => @username,
+                'shift_password'  => @password
+            }
+        end
+
+        def normalize_vm_details(vm_details)
+            details = Array(vm_details).map {|vm| stringify(vm) }
+
+            raise ArgumentError, ':vm_details must not be empty' if details.empty?
+
+            details
+        end
+
+        def require_options!(options, *keys)
+            missing = keys.reject do |key|
+                value = options[key]
+                value.respond_to?(:empty?) ? !value.empty? : !value.nil?
+            end
+
+            return if missing.empty?
+
+            raise ArgumentError, "Missing required option(s): #{missing.join(', ')}"
+        end
+
+        # Deep convert symbol keys so callers can use either style.
+        def stringify(value)
+            case value
+            when Hash
+                value.each_with_object({}) {|(k, v), acc| acc[k.to_s] = stringify(v) }
+            when Array
+                value.map {|v| stringify(v) }
+            else
+                value
+            end
+        end
+
+        def redact(value)
+            case value
+            when Hash
+                value.each_with_object({}) do |(key, val), acc|
+                    acc[key] = key.to_s.match?(/password|passwd|secret/i) ? '[redacted]' : redact(val)
+                end
+            when Array
+                value.map {|v| redact(v) }
+            else
+                value
+            end
+        end
+
+        # -------------------------- REST plumbing ------------------------- #
+
+        # Open a session, yield its id, always end the session.
+        def api_session
+            response = api_request(Net::HTTP::Post, SESSION_PORT, '/api/tenant/session',
+                                   :body => { 'loginId' => @username, 'password' => @password })
+
+            sid = response.dig('session', '_id') || deep_find(response, '_id')
+
+            raise OperationError, 'Shift session: no session id in response' if sid.nil?
+
+            begin
+                yield sid
+            ensure
+                begin
+                    api_request(Net::HTTP::Post, SESSION_PORT, '/api/tenant/session/end',
+                                :body => { 'sessionId' => sid }, :session => sid)
+                rescue StandardError => e
+                    @logger.warn("NetApp Shift: could not end session: #{e.message}")
+                end
+            end
+        end
+
+        # GET a paged setup collection and return its 'list'.
+        def api_list(session_id, path)
+            response = api_request(Net::HTTP::Get, SETUP_PORT, path, :session => session_id)
+
+            Array(response['list'])
+        end
+
+        def api_find_blueprint(session_id, blueprint_name)
+            blueprints = api_list(session_id, '/api/setup/drplan')
+            blueprint  = blueprints.find {|bp| bp['name'] == blueprint_name }
+
+            if blueprint.nil?
+                known = blueprints.map {|bp| bp['name'] }.compact
+                raise OperationError,
+                      "Blueprint '#{blueprint_name}' not found on #{@server}. " \
+                      "Available blueprints: #{known.empty? ? '(none)' : known.join(', ')}"
+            end
+
+            blueprint
+        end
+
+        # One JSON request against the appliance. TLS verification is off to
+        # match the Python (verify=False) -- Shift appliances ship self-signed
+        # certificates.
+        def api_request(method_class, port, path, body: nil, session: nil, timeout: 30)
+            uri  = URI.parse("#{@server}:#{port}#{path}")
+            http = Net::HTTP.new(uri.host, uri.port)
+
+            http.use_ssl      = uri.scheme == 'https'
+            http.verify_mode  = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
+            http.open_timeout = timeout
+            http.read_timeout = timeout
+
+            request = method_class.new(uri.request_uri)
+            request['Content-Type'] = 'application/json'
+            request['netapp-sie-sessionid'] = session if session
+            request.body = JSON.generate(body) if body
+
+            response = http.request(request)
+
+            unless response.is_a?(Net::HTTPSuccess)
+                raise OperationError,
+                      "Shift API #{path} returned #{response.code}: " \
+                      "#{response.body.to_s[0, 200]}"
+            end
+
+            response.body.to_s.empty? ? {} : JSON.parse(response.body)
+        rescue JSON::ParserError => e
+            raise OperationError, "Shift API #{path} returned invalid JSON: #{e.message}"
+        rescue SystemCallError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
+            raise OperationError, "Shift API #{path} failed: #{e.class}: #{e.message}"
+        end
+
+        # First value for key anywhere in a nested structure (the session
+        # response nests the id; mirrors the Python's parse_json search).
+        def deep_find(obj, key)
+            case obj
+            when Hash
+                return obj[key] if obj.key?(key)
+
+                obj.each_value do |v|
+                    found = deep_find(v, key)
+                    return found unless found.nil?
+                end
+                nil
+            when Array
+                obj.each do |item|
+                    found = deep_find(item, key)
+                    return found unless found.nil?
+                end
+                nil
+            end
+        end
+
+        # ------------------------ script plumbing ------------------------- #
+
+        # Render the payload to the fixed path the script reads, run the block,
+        # then put the original file back.
+        #
+        # The path comes from Config.yml and cannot be overridden per run, so
+        # concurrent helpers would clobber each other -- hence the lock. The
+        # file holds plaintext credentials while it exists, so it is written
+        # 0600 and its previous mode is restored along with its contents.
+        def with_payload(name, payload)
+            path = File.join(@script_dir, "#{name}.json")
+
+            lock(name) do
+                original = File.exist?(path) ? File.binread(path) : nil
+                mode     = File.exist?(path) ? File.stat(path).mode : nil
+
+                begin
+                    FileUtils.touch(path)
+                    File.chmod(0o600, path)
+                    File.write(path, JSON.pretty_generate(payload))
+
+                    yield path
+                ensure
+                    if @keep_payload
+                        @logger.warn("NetApp Shift: leaving #{path} in place; " \
+                                     'it contains plaintext credentials')
+                    elsif original
+                        File.write(path, original)
+                        File.chmod(mode, path) if mode
+                    else
+                        FileUtils.rm_f(path)
+                    end
+                end
+            end
+        end
+
+        # Serialize helpers that share a script directory. The lock lives in
+        # tmp so it never shows up as untracked noise in the submodule.
+        def lock(name)
+            key  = Digest::SHA256.hexdigest("#{@script_dir}/#{name}")[0, 16]
+            path = File.join(Dir.tmpdir, "oneswap-shift-#{key}.lock")
+
+            File.open(path, File::RDWR | File::CREAT, 0o600) do |file|
+                unless file.flock(File::LOCK_EX | File::LOCK_NB)
+                    @logger.info("NetApp Shift: waiting for #{name} payload lock")
+                    file.flock(File::LOCK_EX)
+                end
+
+                begin
+                    yield
+                ensure
+                    file.flock(File::LOCK_UN)
+                end
+            end
+        end
+
+        # Run a script from the Python directory, streaming its output to the
+        # log and enforcing a timeout.
+        #
+        # CWD matters twice over: the scripts import siblings (api_wrapper,
+        # utils, conftest) and log_config creates its logs/ tree relative to
+        # the working directory.
+        #
+        # Python's logging writes to stderr, so both streams are captured and
+        # merged; get_site.py attaches a second StreamHandler and so logs
+        # every line twice.
+        #
+        # @return [Array] [output, status, timed_out, duration]
+        def execute(script, timeout)
+            @logger.info("NetApp Shift: running #{script} (timeout #{timeout}s)")
+
+            buffer    = +''
+            mutex     = Mutex.new
+            timed_out = false
+            status    = nil
+            t0        = Time.now
+
+            Open3.popen3(@python, script,
+                         :chdir => @script_dir,
+                         :pgroup => true) do |stdin, out, err, wait_thr|
+                stdin.close
+
+                readers = [out, err].map do |io|
+                    Thread.new do
+                        io.each_line do |line|
+                            mutex.synchronize { buffer << line }
+                            @logger.debug("[shift] #{line.chomp}")
+                        end
+                    rescue IOError
+                        nil
+                    end
+                end
+
+                unless wait_thr.join(timeout)
+                    timed_out = true
+                    @logger.error("NetApp Shift: #{script} exceeded #{timeout}s, terminating")
+                    kill_process_group(wait_thr.pid)
+                end
+
+                status = wait_thr.value
+
+                readers.each {|thread| thread.join(5) }
+                readers.each(&:kill)
+            end
+
+            [buffer, status, timed_out, (Time.now - t0).round(2)]
+        end
+
+        # Sends TERM then KILL to the process group led by pid.
+        def kill_process_group(pid)
+            Process.kill('TERM', -pid)
+            sleep 5
+            Process.kill('KILL', -pid)
+        rescue Errno::ESRCH, Errno::EPERM
+            nil
+        end
+
+        def log_result(result)
+            if result.ok?
+                @logger.info("NetApp Shift: #{result}")
+            else
+                @logger.error("NetApp Shift: #{result}")
+                result.errors.each {|line| @logger.error("[shift] #{line}") }
+            end
+        end
+
+        LOG_LINE = /^[\d\-]+ [\d:,]+ - \S+ - (?<level>\w+) - (?<message>.*)$/.freeze
+
+        def error_lines(output)
+            output.each_line.filter_map do |line|
+                match = LOG_LINE.match(line.chomp)
+                next unless match && match[:level] == 'ERROR'
+
+                match[:message]
+            end.uniq
+        end
+
+        # ------------------------------------------------------------------ #
+        # Output scraping                                                     #
+        #                                                                     #
+        # The strings below are the log messages the upstream scripts emit on #
+        # success. They are the only machine readable signal available, so    #
+        # they need re-checking whenever the submodule is bumped.             #
+        # ------------------------------------------------------------------ #
+
+        def parse(operation, output)
+            case operation
+            when :get_site               then parse_get_site(output)
+            when :create_blueprint       then parse_create_blueprint(output)
+            when :run_compliance_check   then parse_compliance(output)
+            when :trigger_migration      then parse_trigger_migration(output)
+            when :check_migration_status then parse_migration_status(output)
+            else { :ok => false }
+            end
+        end
+
+        def parse_get_site(output)
+            { :ok => output.include?('Site details fetched successfully') }
+        end
+
+        def parse_create_blueprint(output)
+            id = output[/Blueprint created with id:\s*(\S+)/, 1]
+
+            {
+                :ok           => !id.nil?,
+                :blueprint_id => id,
+                :verified     => output.include?('Verified blueprint details:')
+            }
+        end
+
+        def parse_compliance(output)
+            task_id = output[/Compliance check initiated with task id:\s*(\S+)/, 1]
+            result  = output[/Compliance check passed with result:\s*(.*)$/, 1]
+
+            {
+                :ok                 => !task_id.nil? && !result.nil?,
+                :compliance_task_id => task_id,
+                :compliance_result  => result
+            }
+        end
+
+        def parse_trigger_migration(output)
+            id = output[/Migration triggered for blueprint .* with execution id:\s*(\S+)/, 1]
+
+            { :ok => !id.nil?, :execution_id => id }
+        end
+
+        def parse_migration_status(output)
+            status = output[/Status of Blueprint is (\S+) for blueprint/, 1]
+            jobs   = output.include?('Job steps successfully completed for execution id')
+
+            # verify_blueprint_status returns a real status only once it
+            # contains "complete" or "error"; when its ~20 min polling window
+            # runs out first it returns Python False, which the script logs as
+            # the literal status "False" -- that means "still running", not
+            # "failed". #wait_for_completion keys off :running to re-invoke.
+            complete = status.to_s.include?('complete')
+            running  = status.nil? || status == 'False'
+
+            {
+                :ok           => complete && jobs,
+                :status       => status,
+                :complete     => complete,
+                :running      => running,
+                :jobs_ok      => jobs,
+                :failed_steps => output.scan(/Job step (.*) is not successful/).flatten.uniq
+            }
+        end
+
+    end
+
+end

--- a/oneswap
+++ b/oneswap
@@ -641,6 +641,55 @@ CommandParser::CmdParser.new(ARGV) do
         :format => String
     }
 
+    SHIFT = {
+        :name  => 'shift',
+        :large => '--shift server',
+        :description => 'NetApp Shift Toolkit appliance URL (scheme and host, no port). '\
+                        'Converts disks through a pre-created Shift blueprint instead of virt-v2v. '\
+                        'Without a VM name, --vms or --vm-list, every VM in the blueprint is imported.',
+        :format => String
+    }
+
+    SHIFT_USER = {
+        :name  => 'shift_user',
+        :large => '--shift-user username',
+        :description => 'NetApp Shift username.',
+        :format => String
+    }
+
+    SHIFT_PASS = {
+        :name  => 'shift_pass',
+        :large => '--shift-pass password',
+        :description => 'NetApp Shift password.',
+        :format => String
+    }
+
+    SHIFT_MOUNT = {
+        :name  => 'shift_mount',
+        :large => '--shift-mount /path/to/mount',
+        :description => 'Local mount point of the source NFS datastore where Shift '\
+                        'writes the converted qcow2 disks.',
+        :format => String
+    }
+
+    SHIFT_BLUEPRINT = {
+        :name  => 'shift_blueprint',
+        :large => '--shift-blueprint name',
+        :description => 'Name of the pre-created Shift blueprint (DR plan) to execute. '\
+                        'One execution converts every VM in its resource group(s).',
+        :format => String
+    }
+
+    SHIFT_SKIP_CONVERSION = {
+        :name  => 'shift_skip_conversion',
+        :large => '--shift-skip-conversion',
+        :description => 'Skip the Shift compliance check, trigger and wait; import qcow2 '\
+                        'disks already present on --shift-mount (re-runs and recovery).'
+    }
+
+    SHIFT_OPTS = [SHIFT, SHIFT_USER, SHIFT_PASS, SHIFT_MOUNT, SHIFT_BLUEPRINT,
+                  SHIFT_SKIP_CONVERSION]
+
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, LIBGUESTFS_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT, ALLOW_LOCAL_PATH_REMOTE]
@@ -650,7 +699,7 @@ CommandParser::CmdParser.new(ARGV) do
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
                     SKIP_PRECHEKS, UEFI_PATH, UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
-                    ACCEPT_CERT, ONE_USER, ONE_GROUP, VM_LIST, VMS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS
+                    ACCEPT_CERT, ONE_USER, ONE_GROUP, VM_LIST, VMS] + AUTH_OPTS + ESXI_OPTS + V2V_OPTS + HTTP_OPTS + SHIFT_OPTS
     IMPORT_OPTS = [OVA, VMDK, DATASTORE, NETWORK, SKIP_CONTEXT, REMOVE_VMTOOLS, UEFI_PATH,
                    UEFI_SEC_PATH, INJECT_DNS, CONTEXT_MIN_FREE, CONTEXT_FAIL_LOW_SPACE, CONTEXT_TIMEOUT,
                    ONE_USER, ONE_GROUP] + V2V_OPTS
@@ -727,6 +776,11 @@ CommandParser::CmdParser.new(ARGV) do
 
             oneswap convert --vms vm-web-01,vm-db-01,vm-app-01 $VOPTS [--fallback|--custom|--hybrid]
 
+            - Convert through a NetApp Shift blueprint (all VMs in the blueprint, or one by name):
+
+            SOPTS='--shift https://12.34.56.80 --shift-user admin --shift-pass changeme123'
+            oneswap convert $VOPTS $SOPTS --shift-blueprint bp1 --shift-mount /mnt/shift [vm-name]
+
     EOT
 
     command :convert, conv_desc, [:vm_name, nil], :options => CONVERT_OPTS do
@@ -798,6 +852,48 @@ CommandParser::CmdParser.new(ARGV) do
                 raise 'Cannot define both --fallback and --custom.'
             end
 
+            if options[:shift_skip_conversion] && !options[:shift]
+                raise '--shift-skip-conversion requires --shift.'
+            end
+
+            if options[:shift]
+                incompatible_shift = []
+                incompatible_shift << '--custom' if options[:custom_convert]
+                incompatible_shift << '--fallback' if options[:fallback]
+                incompatible_shift << '--hybrid' if options[:hybrid]
+                incompatible_shift << '--delta' if options[:delta]
+                incompatible_shift << '--delta-prepare' if options[:delta_prepare]
+                incompatible_shift << '--delta-commit' if options[:delta_commit]
+                incompatible_shift << '--delta-cleanup' if options[:delta_cleanup]
+                incompatible_shift << '--vddk' if options[:vddk_path]
+                incompatible_shift << '--esxi' if options[:esxi_ip]
+                incompatible_shift << '--download-stripes' if (options[:download_stripes] || 1).to_i > 1
+                incompatible_shift << '--clone' if options[:clone]
+                incompatible_shift << '--dry-run' if options[:dry_run]
+
+                if !incompatible_shift.empty?
+                    raise "--shift cannot be combined with #{incompatible_shift.join(', ')}."
+                end
+
+                missing_shift = []
+                missing_shift << '--shift-user' unless options[:shift_user]
+                missing_shift << '--shift-pass' unless options[:shift_pass]
+                missing_shift << '--shift-mount' unless options[:shift_mount]
+                missing_shift << '--shift-blueprint' unless options[:shift_blueprint]
+
+                if !missing_shift.empty?
+                    raise "--shift requires #{missing_shift.join(', ')}."
+                end
+
+                if !Dir.exist?(options[:shift_mount])
+                    raise "--shift-mount #{options[:shift_mount]} does not exist or is not a directory."
+                end
+
+                if !system('which virt-v2v-in-place > /dev/null 2>&1')
+                    raise '--shift requires virt-v2v-in-place; install virt-v2v.'
+                end
+            end
+
             options[:work_dir]         ||= WORK_PATH
             options[:format]           ||= 'qcow2'
             options[:context]          ||= '/usr/share/one/context'
@@ -818,6 +914,22 @@ CommandParser::CmdParser.new(ARGV) do
             options[:dry_run_guest_customization_seconds] ||= 180
             options[:dry_run_import_benchmark_size_mib] ||= 4096
             options[:dry_run_source_benchmark_size_mib] ||= 1024
+
+            if options[:shift]
+                # Installed layout: the submodule lands in SCRIPTS_LOCATION.
+                # From a repo checkout the helper falls back to its own
+                # __dir__-relative default when this stays nil.
+                shift_scripts = File.join(SCRIPTS_LOCATION, 'shift-api-automation', 'Python')
+                options[:shift_script_dir] ||= shift_scripts if Dir.exist?(shift_scripts)
+
+                # cleanup (and --delete) remove files under work_dir; the Shift
+                # mount holds the source datastore and must stay out of reach.
+                wd = File.expand_path(options[:work_dir])
+                sm = File.expand_path(options[:shift_mount])
+                if wd == sm || wd.start_with?("#{sm}/") || sm.start_with?("#{wd}/")
+                    raise '--shift-mount and the work directory must not overlap.'
+                end
+            end
 
             if options[:http_transfer]
                 options[:http_host] ||= Socket.ip_address_list.detect do |addrinfo|
@@ -842,9 +954,41 @@ CommandParser::CmdParser.new(ARGV) do
             if modes.size > 1
                 raise 'Specify only one of: positional VM name, --vms, or --vm-list.'
             end
-            raise 'Provide a VM name, --vms vm1,vm2,..., or --vm-list <file>.' if modes.empty?
+            if modes.empty? && !options[:shift]
+                raise 'Provide a VM name, --vms vm1,vm2,..., or --vm-list <file>.'
+            end
 
-            if vm_list
+            if options[:shift]
+                # The blueprint is the unit of conversion: one execution
+                # converts every VM in its resource group(s), so trigger it
+                # once here and let the loop below only import.
+                blueprint_vms = helper.shift_blueprint_vm_names(options)
+
+                requested = if vm_name
+                                [vm_name]
+                            elsif vm_names
+                                vm_names.split(',').map(&:strip).reject(&:empty?)
+                            elsif vm_list
+                                helper.read_vm_list(vm_list)
+                            else
+                                blueprint_vms
+                            end
+                raise 'No VM names requested.' if requested.empty?
+
+                unknown = requested - blueprint_vms
+                if !unknown.empty?
+                    raise "Not in blueprint '#{options[:shift_blueprint]}': "\
+                          "#{unknown.join(', ')}. Blueprint VMs: #{blueprint_vms.join(', ')}"
+                end
+
+                helper.shift_execute_blueprint(options) unless options[:shift_skip_conversion]
+
+                if requested.size > 1
+                    exit helper.convert_vm_list(requested, options)
+                else
+                    helper.convert(requested.first, options)
+                end
+            elsif vm_list
                 exit helper.convert_batch(vm_list, options)
             elsif vm_names
                 names = vm_names.split(',').map(&:strip).reject(&:empty?)

--- a/oneswap
+++ b/oneswap
@@ -687,14 +687,45 @@ CommandParser::CmdParser.new(ARGV) do
                         'disks already present on --shift-mount (re-runs and recovery).'
     }
 
+    SHIFT_SKIP_COMPLIANCE = {
+        :name  => 'shift_skip_compliance',
+        :large => '--shift-skip-compliance',
+        :description => 'Skip the Shift compliance check but still trigger the blueprint. '\
+                        'Useful when it has already been checked, or when resuming.'
+    }
+
+    SHIFT_SKIP_MORPH = {
+        :name  => 'shift_skip_morph',
+        :large => '--shift-skip-morph',
+        :description => 'Import the converted disks without running virt-v2v-in-place. '\
+                        'For guests virt-v2v cannot convert (Alpine and other minimal '\
+                        'distributions) that already carry virtio drivers and boot under KVM.'
+    }
+
+    SHIFT_IGNORE_RUNNING_VMS = {
+        :name  => 'shift_ignore_running_vms',
+        :large => '--shift-ignore-running-vms',
+        :description => 'Convert even if VMs in the blueprint are still powered on. '\
+                        'Shift takes a point-in-time snapshot, so the resulting disks are '\
+                        'crash-consistent rather than quiesced.'
+    }
+
     SHIFT_OPTS = [SHIFT, SHIFT_USER, SHIFT_PASS, SHIFT_MOUNT, SHIFT_BLUEPRINT,
-                  SHIFT_SKIP_CONVERSION]
+                  SHIFT_SKIP_CONVERSION, SHIFT_SKIP_COMPLIANCE, SHIFT_SKIP_MORPH,
+                  SHIFT_IGNORE_RUNNING_VMS]
 
     ESXI_OPTS = [ESXI, ESXI_USER, ESXI_PASS]
     V2V_OPTS = [V2V_PATH, LIBGUESTFS_PATH, WORK_DIR, FORMAT, VIRTIO, WIN_GA, LNX_GA, DELETE, VDDK, RHSRVANY, ROOT]
     HTTP_OPTS = [HTTP_TRANSFER, HTTP_HOST, HTTP_PORT, ALLOW_LOCAL_PATH_REMOTE]
 
-    LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT] + AUTH_OPTS
+    # Listing from Shift needs the appliance and a blueprint, but none of the
+    # conversion-side options (mount, skip-conversion).
+    SHIFT_LIST_OPTS = [SHIFT, SHIFT_USER, SHIFT_PASS, SHIFT_BLUEPRINT]
+
+    # CLIHelper::SIZE is deliberately left out: its short flag is -s, which is
+    # already the short flag for --state above.
+    LIST_OPTS    = [NAME, DATACENTER, CLUSTER, STATE, ACCEPT_CERT,
+                    CLIHelper::EXPAND, CLIHelper::NO_EXPAND] + AUTH_OPTS + SHIFT_LIST_OPTS
     CONVERT_OPTS = [NETWORK, NO_IP, NO_MAC, DATASTORE, CONTEXT, FALLBACK, CUSTOM, HYBRID, DOWNLOAD_STRIPES, DELTA, DELTA_PREPARE, DELTA_COMMIT, DELTA_CLEANUP, DRY_RUN, BENCHMARK_IMPORT, BENCHMARK_EXPORT, V2V_PATH, CONF_FILE, IMG_WAIT, DEV_PREFIX,
                     CPU_MODEL, GRAPHICS_TYPE, GRAPHICS_LISTEN, GRAPHICS_PORT, GRAPHICS_KEYMAP, GRAPHICS_PASSWORD, GRAPHICS_COMMAND, DISABLE_CONTEXTUALIZATION,
                     PERSISTENT_IMG, MEMORY_MAX, VCPU_MAX, CPU, VCPU, ONE_DS, ONE_DS_CLUSTER, ONE_CLUSTER, ONE_HOST, CLONE, REMOVE_VMTOOLS,
@@ -722,6 +753,15 @@ CommandParser::CmdParser.new(ARGV) do
            - listing available vms in a Datacenter and Cluster:
 
              oneswap list vms --datacenter DCName --cluster Cluster2
+
+           - listing the NetApp Shift blueprints available to convert:
+
+             SOPTS='--shift https://12.34.56.80 --shift-user admin --shift-pass changeme123'
+             oneswap list blueprints $SOPTS
+
+           - listing the VMs a blueprint covers, which is what it will convert:
+
+             oneswap list vms $SOPTS --shift-blueprint bp1
 
     EOT
 
@@ -899,6 +939,14 @@ CommandParser::CmdParser.new(ARGV) do
 
                 if !system('which virt-v2v-in-place > /dev/null 2>&1')
                     raise '--shift requires virt-v2v-in-place; install virt-v2v.'
+                end
+
+                # vCenter still supplies the VM properties, NICs and tags the
+                # template is built from. Check it here rather than letting the
+                # run get all the way past a blueprint execution before failing.
+                if !options[:vcenter] || !options[:vuser]
+                    raise 'Shift conversions still read VM properties from vCenter. '\
+                          'Provide --vcenter and --vuser (and --vpass).'
                 end
             end
 

--- a/oneswap
+++ b/oneswap
@@ -733,7 +733,11 @@ CommandParser::CmdParser.new(ARGV) do
             end
 
             cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
-            options.merge!(cfg_file) if cfg_file
+            # Config file supplies defaults; anything given on the command
+            # line wins. `replace` keeps the same Hash object because later
+            # code mutates it in place (convert appends the VM name to
+            # :work_dir).
+            options.replace(cfg_file.merge(options)) if cfg_file
             options[:object] = args[0]
             helper.parse_opts(options)
             helper.list(options)
@@ -790,7 +794,11 @@ CommandParser::CmdParser.new(ARGV) do
             end
             options[:config_file] ||= '/etc/one/oneswap.yaml'
             cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
-            options.merge!(cfg_file) if cfg_file
+            # Config file supplies defaults; anything given on the command
+            # line wins. `replace` keeps the same Hash object because later
+            # code mutates it in place (convert appends the VM name to
+            # :work_dir).
+            options.replace(cfg_file.merge(options)) if cfg_file
 
             if (options[:download_stripes] || 1).to_i > 1 && !options[:hybrid]
                 raise '--download-stripes N > 1 requires --hybrid.'
@@ -1032,7 +1040,11 @@ CommandParser::CmdParser.new(ARGV) do
 
             options[:config_file] ||= '/etc/one/oneswap.yaml'
             cfg_file = normalize_config.call(YAML.load_file(options[:config_file])) if File.exist?(options[:config_file])
-            options.merge!(cfg_file) if cfg_file
+            # Config file supplies defaults; anything given on the command
+            # line wins. `replace` keeps the same Hash object because later
+            # code mutates it in place (convert appends the VM name to
+            # :work_dir).
+            options.replace(cfg_file.merge(options)) if cfg_file
 
             raise 'ESXi Transfer requires at least IP and Password' if options[:esxi_ip] && options[:esxi_pass].nil?
             raise 'ESXI and VDDK cannot be used at same time, recommend VDDK.' if options[:esxi_ip] && options[:vddk_path]

--- a/oneswap
+++ b/oneswap
@@ -924,12 +924,6 @@ CommandParser::CmdParser.new(ARGV) do
             options[:dry_run_source_benchmark_size_mib] ||= 1024
 
             if options[:shift]
-                # Installed layout: the submodule lands in SCRIPTS_LOCATION.
-                # From a repo checkout the helper falls back to its own
-                # __dir__-relative default when this stays nil.
-                shift_scripts = File.join(SCRIPTS_LOCATION, 'shift-api-automation', 'Python')
-                options[:shift_script_dir] ||= shift_scripts if Dir.exist?(shift_scripts)
-
                 # cleanup (and --delete) remove files under work_dir; the Shift
                 # mount holds the source datastore and must stay out of reach.
                 wd = File.expand_path(options[:work_dir])

--- a/oneswap.1
+++ b/oneswap.1
@@ -181,7 +181,12 @@ Examples:
     You can also define \-\-fallback instead of \-\-custom, which will first attempt virt\-v2v style, then fallback to custom\.
 
     oneswap convert vm\-1234 $VOPTS \-\-custom
-valid options: accept_cert, clone, config_file, context, context_fail_on_low_space, context_min_free, context_timeout, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, download_stripes, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, inject_dns, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
+
+    \- Convert through a NetApp Shift blueprint (all VMs in the blueprint, or one by name):
+
+    SOPTS=\'\-\-shift https://12\.34\.56\.80 \-\-shift\-user admin \-\-shift\-pass changeme123\'
+    oneswap convert $VOPTS $SOPTS \-\-shift\-blueprint bp1 \-\-shift\-mount /mnt/shift [vm\-name]
+valid options: accept_cert, clone, config_file, context, context_fail_on_low_space, context_min_free, context_timeout, cpu, cpu_model, custom_convert, datastore, delete, dev_prefix, disable_contextualization, download_stripes, esxi_ip, esxi_pass, esxi_user, fallback, format, graphics_command, graphics_keymap, graphics_listen, graphics_password, graphics_port, graphics_type, http_host, http_port, http_transfer, hybrid, img_wait, inject_dns, memory_max, network, one_cluster, one_datastore, one_datastore_cluster, one_host, persistent_img, port, qemu_ga_linux, qemu_ga_win, remove_vmtools, root, shift, shift_blueprint, shift_mount, shift_pass, shift_skip_conversion, shift_user, skip_ip, skip_mac, skip_prechecks, uefi_path, uefi_sec_path, v2v_path, v2v_path, vcenter, vcpu, vcpu_max, vddk_path, virt_tools, virtio_path, vpass, vuser, work_dir
 .
 .fi
 .

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -16,6 +16,18 @@
 #:esxi_user: 'root'                       # ESXi username. Also used by delta prepare/commit when passwordless SSH is not available.
 #:esxi_pass: 'changeme123'                # ESXi password. Also used by delta prepare/commit when passwordless SSH is not available.
 
+# NetApp Shift Options
+# Note: like every key here, an uncommented value overrides the command line;
+# an uncommented :shift: forces Shift mode for every convert run.
+#:shift: 'https://172.20.0.124'           # Shift Toolkit appliance URL (scheme and host, no port)
+#:shift_user: 'admin'                     # Shift username
+#:shift_pass: 'changeme123'               # Shift password
+#:shift_mount: '/mnt/shift'               # Local mount of the source NFS datastore holding the converted qcow2 disks
+#:shift_blueprint: 'bp-name'              # Pre-created blueprint (DR plan) to execute; one run converts every VM in it
+#:shift_skip_conversion: false            # Skip compliance/trigger/wait and import qcow2 disks already on the mount
+#:shift_wait_timeout: 0                   # Max seconds to wait for the blueprint execution (0 waits until Ctrl+C)
+#:shift_script_dir:                       # Override the shift-api-automation/Python scripts directory
+
 # Transfer Options
 #:custom_convert:                         # Uses OpenNebula's custom conversion process, useful for distributions which are not supported or fail to convert
 #:fallback:                               # Fallback to OpenNebula's custom conversion process

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -1,3 +1,6 @@
+# Values here are defaults. Anything passed on the command line overrides
+# them, so per-VM customisations do not require editing this file.
+
 # OpenNebula Transfer Options, required for remote OpenNebula server
 #:http_transfer: false                    # Enable HTTP transfer
 #:http_host: '192.168.0.10'               # Hostname of this server
@@ -17,8 +20,7 @@
 #:esxi_pass: 'changeme123'                # ESXi password. Also used by delta prepare/commit when passwordless SSH is not available.
 
 # NetApp Shift Options
-# Note: like every key here, an uncommented value overrides the command line;
-# an uncommented :shift: forces Shift mode for every convert run.
+# Note: an uncommented :shift: puts every convert run into Shift mode.
 #:shift: 'https://172.20.0.124'           # Shift Toolkit appliance URL (scheme and host, no port)
 #:shift_user: 'admin'                     # Shift username
 #:shift_pass: 'changeme123'               # Shift password
@@ -84,7 +86,7 @@
 #:uefi_sec_path: '/usr/share/OVMF/OVMF_CODE.secboot.fd'     # Path to the UEFI Secure file to be configured in the VM template.
 
 # Logging Options
-#:verbose: true                           # Verbose mode: log at DEBUG and echo diagnostics to the terminal (STDERR) as well as /var/log/one/oneswap.log. Equivalent to the -v/--verbose flag or the ONE_SWAP_DEBUG env var. Note: like every option here, an uncommented value takes precedence over the command line.
+#:verbose: true                           # Verbose mode: log at DEBUG and echo diagnostics to the terminal (STDERR) as well as /var/log/one/oneswap.log. Equivalent to the -v/--verbose flag or the ONE_SWAP_DEBUG env var.
 
 # OpenNebula Placement Options
 #:one_cluster:                            # ID of the OpenNebula Cluster

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -28,7 +28,6 @@
 #:shift_blueprint: 'bp-name'              # Pre-created blueprint (DR plan) to execute; one run converts every VM in it
 #:shift_skip_conversion: false            # Skip compliance/trigger/wait and import qcow2 disks already on the mount
 #:shift_wait_timeout: 0                   # Max seconds to wait for the blueprint execution (0 waits until Ctrl+C)
-#:shift_script_dir:                       # Override the shift-api-automation/Python scripts directory
 
 # Transfer Options
 #:custom_convert:                         # Uses OpenNebula's custom conversion process, useful for distributions which are not supported or fail to convert

--- a/oneswap.yaml
+++ b/oneswap.yaml
@@ -27,6 +27,9 @@
 #:shift_mount: '/mnt/shift'               # Local mount of the source NFS datastore holding the converted qcow2 disks
 #:shift_blueprint: 'bp-name'              # Pre-created blueprint (DR plan) to execute; one run converts every VM in it
 #:shift_skip_conversion: false            # Skip compliance/trigger/wait and import qcow2 disks already on the mount
+#:shift_skip_compliance: false            # Skip the compliance check but still trigger the blueprint
+#:shift_skip_morph: false                 # Import the converted disks without virt-v2v-in-place (guest must already boot on KVM)
+#:shift_ignore_running_vms: false         # Convert even if blueprint VMs are powered on (crash-consistent snapshot)
 #:shift_wait_timeout: 0                   # Max seconds to wait for the blueprint execution (0 waits until Ctrl+C)
 
 # Transfer Options

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -3916,11 +3916,11 @@ GUESTFISH
         if state && state[:complete]
             shift_already_converted(bp, options)
             return
-        elsif state && state[:running]
+        elsif state && state[:running] && state[:execution_id]
             puts "Blueprint '#{bp}' is already executing (#{state[:status]}); waiting for it."
-            status = shift.wait_for_completion(bp, state[:execution_id],
-                                               :timeout => options[:shift_wait_timeout])
-            puts "Shift blueprint '#{bp}' finished: #{status[:status]}".green
+            shift.wait_for_completion(bp, state[:execution_id],
+                                      :timeout => options[:shift_wait_timeout])
+            puts "Shift blueprint '#{bp}' finished.".green
             return
         elsif state && state[:failed]
             raise "Blueprint '#{bp}' last execution failed (#{state[:status]}). "\
@@ -3928,27 +3928,22 @@ GUESTFISH
         end
 
         puts "Running Shift compliance check for blueprint '#{bp}'..."
-        shift.check!(shift.run_compliance_check(bp))
+        shift.run_compliance_check(bp)
 
-        puts "Triggering Shift blueprint execution (#{NetAppShift::Helper::CONVERSION})..."
-        trigger = shift.trigger_migration(bp)
-
-        # Shift rejects a second execution of a blueprint that already
-        # converted (ERSCSTEX009). The disks are on the datastore, so that is
-        # a no-op for us, not an error.
-        if trigger[:already_executed]
+        puts 'Triggering Shift blueprint execution (convert)...'
+        begin
+            exec_id = shift.trigger_conversion(bp)
+        rescue NetAppShift::AlreadyExecuted
+            # Shift refuses a second execution of a blueprint that already
+            # converted. The disks are on the datastore, so that is a no-op
+            # for us, not an error.
             shift_already_converted(bp, options)
             return
         end
 
-        shift.check!(trigger)
-
-        exec_id = trigger[:execution_id]
-        raise 'Shift accepted the blueprint execution but reported no execution id' if exec_id.nil?
-
         puts "Waiting for Shift execution #{exec_id} to complete (Ctrl+C to abort)..."
-        status = shift.wait_for_completion(bp, exec_id, :timeout => options[:shift_wait_timeout])
-        puts "Shift blueprint '#{bp}' finished: #{status[:status]}".green
+        shift.wait_for_completion(bp, exec_id, :timeout => options[:shift_wait_timeout])
+        puts "Shift blueprint '#{bp}' finished.".green
     rescue NetAppShift::Error => e
         raise e.message
     end
@@ -3965,11 +3960,10 @@ GUESTFISH
     # Shared NetAppShift::Helper constructor for the shift_* entry points.
     def new_netapp_shift(options)
         NetAppShift::Helper.new(
-            :server     => options[:shift],
-            :username   => options[:shift_user],
-            :password   => options[:shift_pass],
-            :script_dir => options[:shift_script_dir],
-            :logger     => @logger
+            :server   => options[:shift],
+            :username => options[:shift_user],
+            :password => options[:shift_pass],
+            :logger   => @logger
         )
     end
 

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1377,7 +1377,7 @@ _EOF_"
     #   - /path/to/qemu-ga-x86_64.msi         direct MSI file
     #   - /path/to/mounted-virtio-win/        directory already mounted
     #   - /path/to/virtio-win.iso             ISO file (mounted temporarily)
-     def resolve_qemu_ga_msi(path)
+    def resolve_qemu_ga_msi(path)
         if path.end_with?('.msi') && File.exist?(path)
             path
         elsif File.directory?(path)

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -18,6 +18,7 @@ require 'one_helper'
 require 'opennebula'
 require 'logger'
 require 'fileutils'
+require 'rexml/document'
 require 'shellwords'
 require 'socket'
 require 'tempfile'
@@ -30,6 +31,7 @@ require_relative 'vsphere_client'
 require_relative 'esxi_vm'
 require_relative 'windows_tuner'
 require_relative 'oneswap_logger'
+require_relative 'netapp_shift_helper'
 
 class String
 
@@ -1913,6 +1915,70 @@ _EOF_"
         disks_on_file = Dir.children(conversion_dir).map {|disk| File.join(conversion_dir, disk) }
 
         create_one_images(disks_on_file)
+    end
+
+    # NetApp Shift conversion. The blueprint execution (triggered once per
+    # invocation, before the per-VM loop) already wrote the converted qcow2
+    # disks to the source NFS datastore, so this only morphs and imports.
+    #
+    # The morph runs virt-v2v-in-place directly against the files on the
+    # mount -- no local copy, since guest disks can exceed the worker's local
+    # storage. That mutates Shift's output: regenerating a disk means
+    # re-running the blueprint.
+    def run_shift_conversion
+        local_path_image_allocation_preflight!
+
+        disk_count = vc_virtual_disks.length
+        raise "vCenter reports no virtual disks for #{@options[:name]}" if disk_count.zero?
+
+        shift = new_netapp_shift(@options)
+        disks = shift.converted_disks(@options[:name], @options[:shift_mount], disk_count)
+
+        env = v2v_env
+        warn_unreadable_kernel_for_libguestfs(env)
+        env_prefix = env.map {|k, v| "#{k}=#{Shellwords.escape(v)} " }.join
+
+        # -i disk only accepts a single disk; multi-disk guests go through a
+        # minimal libvirt domain XML so inspection sees the whole guest.
+        input = if disks.length == 1
+                    "-i disk #{Shellwords.escape(disks.first)}"
+                else
+                    "-i libvirtxml #{Shellwords.escape(write_shift_domain_xml(disks))}"
+                end
+
+        _stdout, status = run_cmd_report(
+            "#{env_prefix}virt-v2v-in-place #{input} -v --machine-readable", true
+        )
+        raise "virt-v2v-in-place failed for #{@options[:name]}" unless status.success?
+
+        create_one_images(disks)
+    end
+
+    # Minimal libvirt domain definition referencing the converted disks in
+    # order, written into work_dir for virt-v2v-in-place -i libvirtxml.
+    def write_shift_domain_xml(disks)
+        doc = REXML::Document.new
+        doc << REXML::XMLDecl.new
+
+        domain = doc.add_element('domain', 'type' => 'kvm')
+        domain.add_element('name').text = @options[:name]
+        memory_mb = @props.dig('config', :hardware, :memoryMB) || 1024
+        domain.add_element('memory', 'unit' => 'MiB').text = memory_mb.to_s
+        domain.add_element('vcpu').text = '1'
+        domain.add_element('os').add_element('type').text = 'hvm'
+
+        devices = domain.add_element('devices')
+        disks.each_with_index do |path, i|
+            disk = devices.add_element('disk', 'type' => 'file', 'device' => 'disk')
+            disk.add_element('driver', 'name' => 'qemu', 'type' => 'qcow2')
+            disk.add_element('source', 'file' => path)
+            disk.add_element('target', 'dev' => "sd#{('a'.ord + i).chr}", 'bus' => 'scsi')
+        end
+
+        xml_path = File.join(@options[:work_dir], "#{@options[:name]}-shift-domain.xml")
+        File.open(xml_path, 'w') {|f| doc.write(f, 2) }
+
+        xml_path
     end
 
     def local_path_image_allocation_preflight!
@@ -3811,6 +3877,62 @@ GUESTFISH
         end
     end
 
+    # VM names a Shift blueprint would convert, straight from the appliance.
+    # Used to default the batch to "everything in the blueprint" and to
+    # validate requested names before triggering a long conversion.
+    #
+    # @param options [Hash] CLI options (shift server/credentials/blueprint)
+    # @return [Array<String>]
+    def shift_blueprint_vm_names(options)
+        apply_verbosity(options)
+
+        new_netapp_shift(options).blueprint_vm_names(options[:shift_blueprint])
+    rescue NetAppShift::Error => e
+        raise e.message
+    end
+
+    # Trigger the Shift blueprint execution and block until it completes.
+    # Called once per invocation, before the per-VM import loop: one
+    # execution converts every VM in the blueprint's resource group(s).
+    #
+    # @param options [Hash] CLI options (shift server/credentials/blueprint)
+    def shift_execute_blueprint(options)
+        apply_verbosity(options)
+        @options = options
+        check_one_connectivity
+        # Fail before hours of conversion if the frontend could not import
+        # the disks afterwards.
+        local_path_image_allocation_preflight!
+
+        shift = new_netapp_shift(options)
+        bp    = options[:shift_blueprint]
+
+        puts "Running Shift compliance check for blueprint '#{bp}'..."
+        shift.check!(shift.run_compliance_check(bp))
+
+        puts "Triggering Shift blueprint execution (#{NetAppShift::Helper::CONVERSION})..."
+        trigger = shift.check!(shift.trigger_migration(bp))
+        exec_id = trigger[:execution_id]
+        raise 'Shift accepted the blueprint execution but reported no execution id' if exec_id.nil?
+
+        puts "Waiting for Shift execution #{exec_id} to complete (Ctrl+C to abort)..."
+        status = shift.wait_for_completion(bp, exec_id, :timeout => options[:shift_wait_timeout])
+        puts "Shift blueprint '#{bp}' finished: #{status[:status]}".green
+    rescue NetAppShift::Error => e
+        raise e.message
+    end
+
+    # Shared NetAppShift::Helper constructor for the shift_* entry points.
+    def new_netapp_shift(options)
+        NetAppShift::Helper.new(
+            :server     => options[:shift],
+            :username   => options[:shift_user],
+            :password   => options[:shift_pass],
+            :script_dir => options[:shift_script_dir],
+            :logger     => @logger
+        )
+    end
+
     # Read and parse a VM list file for batch conversion.
     # Empty lines and lines starting with # are ignored.
     #
@@ -4220,6 +4342,8 @@ GUESTFISH
                       run_custom_conversion
                   elsif @options[:delta]
                       run_delta_conversion
+                  elsif @options[:shift]
+                      run_shift_conversion
                   else
                       run_v2v_conversion
                   end

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -1984,7 +1984,7 @@ _EOF_"
     def local_path_image_allocation_preflight!
         return if @options[:http_transfer]
 
-        puts 'Local PATH mode requires OneSwap to run on the OpenNebula frontend or work_dir to be shared at the same path.'
+        @logger.debug 'Local PATH mode requires OneSwap to run on the OpenNebula frontend or work_dir to be shared at the same path.'
 
         endpoint_host = opennebula_endpoint_host
         return if endpoint_host.nil? || local_opennebula_endpoint?(endpoint_host)
@@ -3907,11 +3907,42 @@ GUESTFISH
         shift = new_netapp_shift(options)
         bp    = options[:shift_blueprint]
 
+        # A blueprint that has already executed cannot be executed again until
+        # its prior executions are cleared, and one execution converts every VM
+        # in the resource group anyway. So importing more VMs from the same
+        # blueprint is the normal case, not a re-conversion.
+        state = shift.blueprint_execution_state(bp)
+
+        if state && state[:complete]
+            shift_already_converted(bp, options)
+            return
+        elsif state && state[:running]
+            puts "Blueprint '#{bp}' is already executing (#{state[:status]}); waiting for it."
+            status = shift.wait_for_completion(bp, state[:execution_id],
+                                               :timeout => options[:shift_wait_timeout])
+            puts "Shift blueprint '#{bp}' finished: #{status[:status]}".green
+            return
+        elsif state && state[:failed]
+            raise "Blueprint '#{bp}' last execution failed (#{state[:status]}). "\
+                  'Inspect and clear it in the Shift UI before retrying.'
+        end
+
         puts "Running Shift compliance check for blueprint '#{bp}'..."
         shift.check!(shift.run_compliance_check(bp))
 
         puts "Triggering Shift blueprint execution (#{NetAppShift::Helper::CONVERSION})..."
-        trigger = shift.check!(shift.trigger_migration(bp))
+        trigger = shift.trigger_migration(bp)
+
+        # Shift rejects a second execution of a blueprint that already
+        # converted (ERSCSTEX009). The disks are on the datastore, so that is
+        # a no-op for us, not an error.
+        if trigger[:already_executed]
+            shift_already_converted(bp, options)
+            return
+        end
+
+        shift.check!(trigger)
+
         exec_id = trigger[:execution_id]
         raise 'Shift accepted the blueprint execution but reported no execution id' if exec_id.nil?
 
@@ -3920,6 +3951,15 @@ GUESTFISH
         puts "Shift blueprint '#{bp}' finished: #{status[:status]}".green
     rescue NetAppShift::Error => e
         raise e.message
+    end
+
+    # Report that a blueprint's conversion is already done and its disks are
+    # being reused rather than regenerated.
+    def shift_already_converted(blueprint, options)
+        puts "Blueprint '#{blueprint}' has already been converted.".green
+        puts "Reusing the existing qcow2 disks on #{options[:shift_mount]}."
+        puts 'To convert again, clear the blueprint execution in the Shift UI '\
+             '(or with removeBpJobs.ps1) and re-run.'
     end
 
     # Shared NetAppShift::Helper constructor for the shift_* entry points.

--- a/oneswap_helper.rb
+++ b/oneswap_helper.rb
@@ -16,6 +16,7 @@
 
 require 'one_helper'
 require 'opennebula'
+require 'json'
 require 'logger'
 require 'fileutils'
 require 'rexml/document'
@@ -190,6 +191,10 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
         VM         = 1
         DATACENTER = 2
         CLUSTER    = 3
+        # Listed from a NetApp Shift blueprint rather than vCenter, so they
+        # carry a different (much smaller) set of columns.
+        SHIFT_VM   = 4
+        BLUEPRINT  = 5
 
     end
 
@@ -234,6 +239,18 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
             :columns => { :NAME => 30, :VMCOUNT => 35 },
             :cli     => [],
             :dialgoue => ->(arg) {}
+        },
+        VOBJECT::SHIFT_VM => {
+            :struct  => ['VM_LIST', 'VM'],
+            :columns => { :NAME => 40, :RESOURCE_GROUP => 30 },
+            :cli     => [],
+            :dialogue => ->(arg) {}
+        },
+        VOBJECT::BLUEPRINT => {
+            :struct  => ['BLUEPRINT_LIST', 'BLUEPRINT'],
+            :columns => { :NAME => 30, :RESOURCE_GROUP => 30, :VMCOUNT => 7 },
+            :cli     => [],
+            :dialogue => ->(arg) {}
         }
     }
 
@@ -271,9 +288,11 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
             @vobject = VOBJECT::CLUSTER
         when 'vms'
             @vobject = VOBJECT::VM
+        when 'blueprints'
+            @vobject = VOBJECT::BLUEPRINT
         else
             raise 'Invalid object type, must be any of: '\
-                  '[ networks, datacenters, clusters, vms ]'
+                  '[ networks, datacenters, clusters, vms, blueprints ]'
         end
     end
 
@@ -396,6 +415,11 @@ class OneSwapHelper < OpenNebulaHelper::OneHelper
             column :VMCOUNT, '# VMS', :left, :expand,
                    :size=>config[:PATH] || 7 do |d|
                 d[:vm_count]
+            end
+
+            column :RESOURCE_GROUP, 'RESOURCE GROUP', :left, :expand,
+                   :size=>config[:RESOURCE_GROUP] || 25 do |d|
+                d[:resource_group]
             end
 
             column :STATE, 'STATE', :left, :expand,
@@ -1934,6 +1958,19 @@ _EOF_"
         shift = new_netapp_shift(@options)
         disks = shift.converted_disks(@options[:name], @options[:shift_mount], disk_count)
 
+        if @options[:shift_skip_morph]
+            puts 'Skipping virt-v2v-in-place; importing the converted disks unmodified.'.brown
+            puts 'The guest must already boot under KVM (virtio drivers present).'.brown
+        end
+
+        morph_shift_disks(disks) unless @options[:shift_skip_morph]
+
+        create_one_images(disks)
+    end
+
+    # Run the OS morph (virtio drivers, initramfs, bootloader) against the
+    # converted disks, in place on the mount.
+    def morph_shift_disks(disks)
         env = v2v_env
         warn_unreadable_kernel_for_libguestfs(env)
         env_prefix = env.map {|k, v| "#{k}=#{Shellwords.escape(v)} " }.join
@@ -1946,12 +1983,52 @@ _EOF_"
                     "-i libvirtxml #{Shellwords.escape(write_shift_domain_xml(disks))}"
                 end
 
-        _stdout, status = run_cmd_report(
+        stdout, status = run_cmd_report(
             "#{env_prefix}virt-v2v-in-place #{input} -v --machine-readable", true
         )
-        raise "virt-v2v-in-place failed for #{@options[:name]}" unless status.success?
 
-        create_one_images(disks)
+        return if status.success?
+
+        reason = v2v_failure_reason(stdout)
+
+        # virt-v2v only morphs guests it recognises. Plenty of minimal
+        # distributions do not need it -- they already carry virtio -- so
+        # point at the flag instead of just failing.
+        if reason.include?('unable to convert this guest type')
+            raise "virt-v2v-in-place cannot convert this guest: #{reason}\n"\
+                  'If it already boots under KVM (minimal distributions such as Alpine '\
+                  'usually do, having virtio built in), re-run with --shift-skip-morph '\
+                  'to import the converted disks without the OS morph.'
+        end
+
+        raise "virt-v2v-in-place failed for #{@options[:name]}: #{reason}"
+    end
+
+    # Pull the real reason out of a failed virt-v2v run.
+    #
+    # --machine-readable makes virt-v2v emit JSON objects on stdout, so the
+    # error it actually hit is in there. Without this the caller only sees
+    # whatever libguestfs left on the terminal, which is usually teardown
+    # noise (failing fsyncs as the appliance is destroyed) rather than the
+    # first failure.
+    def v2v_failure_reason(output)
+        messages = output.to_s.each_line.filter_map do |line|
+            parsed = begin
+                JSON.parse(line)
+            rescue JSON::ParserError
+                nil
+            end
+
+            next unless parsed.is_a?(Hash) && parsed['type'] == 'error'
+
+            parsed['message']
+        end
+
+        return messages.uniq.join('; ') unless messages.empty?
+
+        tail = output.to_s.each_line.map(&:chomp).reject(&:empty?).last(5)
+
+        tail.empty? ? 'no output captured, re-run with -v for the full log' : tail.join(' | ')
     end
 
     # Minimal libvirt domain definition referencing the converted disks in
@@ -1962,9 +2039,11 @@ _EOF_"
 
         domain = doc.add_element('domain', 'type' => 'kvm')
         domain.add_element('name').text = @options[:name]
-        memory_mb = @props.dig('config', :hardware, :memoryMB) || 1024
-        domain.add_element('memory', 'unit' => 'MiB').text = memory_mb.to_s
-        domain.add_element('vcpu').text = '1'
+        # 'config' is an RbVmomi VirtualMachineConfigInfo, which supports []
+        # but not #dig. Chain [] the way the rest of the template code does.
+        hardware = @props['config'][:hardware]
+        domain.add_element('memory', 'unit' => 'MiB').text = (hardware[:memoryMB] || 1024).to_s
+        domain.add_element('vcpu').text = (hardware[:numCPU] || 1).to_s
         domain.add_element('os').add_element('type').text = 'hvm'
 
         devices = domain.add_element('devices')
@@ -1976,7 +2055,10 @@ _EOF_"
         end
 
         xml_path = File.join(@options[:work_dir], "#{@options[:name]}-shift-domain.xml")
-        File.open(xml_path, 'w') {|f| doc.write(f, 2) }
+        # Write unformatted. REXML's indent argument pads every text node with
+        # newlines, and virt-v2v reads /domain/memory/text() as an integer --
+        # "\n    4096\n  " makes it bail before it ever looks at the disks.
+        File.open(xml_path, 'w') {|f| doc.write(f) }
 
         xml_path
     end
@@ -3828,11 +3910,78 @@ GUESTFISH
             list_datacenters(options)
         when 'clusters'
             list_clusters(options)
+        when 'blueprints'
+            list_shift_blueprints(options)
         when 'vms'
-            list_vms(options)
+            # With Shift configured, "vms" means the VMs a blueprint would
+            # convert. Datacenters and clusters are vCenter concepts and stay
+            # on the vCenter path either way.
+            if options[:shift]
+                list_shift_vms(options)
+            else
+                list_vms(options)
+            end
         else
             raise 'Invalid object type for listing'.brown
         end
+    end
+
+    # List the VMs a Shift blueprint covers -- everything one execution of it
+    # would convert, and therefore everything importable from it.
+    #
+    # @param options [Hash] User CLI options
+    def list_shift_vms(options)
+        require_shift_listing_options!(options, :shift_blueprint)
+
+        @vobject = VOBJECT::SHIFT_VM
+
+        vms = new_netapp_shift(options).blueprint_vms(options[:shift_blueprint])
+
+        if options[:name]
+            vms = vms.select {|vm| vm[:name].to_s.include?(options[:name]) }
+        end
+
+        format_list.show(vms, options)
+    rescue NetAppShift::Error => e
+        raise e.message
+    end
+
+    # List the blueprints on the appliance, so the right one can be picked
+    # before committing to a conversion.
+    #
+    # @param options [Hash] User CLI options
+    def list_shift_blueprints(options)
+        require_shift_listing_options!(options)
+
+        @vobject = VOBJECT::BLUEPRINT
+
+        blueprints = new_netapp_shift(options).blueprint_summaries
+
+        if options[:name]
+            blueprints = blueprints.select {|bp| bp[:name].to_s.include?(options[:name]) }
+        end
+
+        list = blueprints.map do |bp|
+            {
+                :name           => bp[:name],
+                :resource_group => bp[:resource_groups].join(', '),
+                :vm_count       => bp[:vms].length
+            }
+        end
+
+        format_list.show(list, options)
+    rescue NetAppShift::Error => e
+        raise e.message
+    end
+
+    # Shift listings need credentials but none of the conversion-side options
+    # (mount, work dir), so they are checked here rather than in the CLI.
+    def require_shift_listing_options!(options, *extra)
+        missing = ([:shift, :shift_user, :shift_pass] + extra).reject {|key| options[key] }
+
+        return if missing.empty?
+
+        raise "Listing from NetApp Shift requires #{missing.map {|m| "--#{m.to_s.tr('_', '-')}" }.join(', ')}."
     end
 
     # General wrapper to fix options and handle fatal errors
@@ -3927,18 +4076,32 @@ GUESTFISH
                   'Inspect and clear it in the Shift UI before retrying.'
         end
 
-        puts "Running Shift compliance check for blueprint '#{bp}'..."
-        shift.run_compliance_check(bp)
+        if options[:shift_skip_compliance]
+            puts 'Skipping Shift compliance check.'
+        else
+            puts "Running Shift compliance check for blueprint '#{bp}'..."
+            shift.run_compliance_check(bp)
+        end
 
         puts 'Triggering Shift blueprint execution (convert)...'
         begin
-            exec_id = shift.trigger_conversion(bp)
+            exec_id = shift.trigger_conversion(
+                bp, :ignore_powered_on => options[:shift_ignore_running_vms] ? true : false
+            )
         rescue NetAppShift::AlreadyExecuted
             # Shift refuses a second execution of a blueprint that already
             # converted. The disks are on the datastore, so that is a no-op
             # for us, not an error.
             shift_already_converted(bp, options)
             return
+        rescue NetAppShift::PoweredOnVms => e
+            # Recoverable, and the fix is a flag away -- say so rather than
+            # leaving the operator to work it out from an error code.
+            running = e.vm_names.empty? ? '' : " (#{e.vm_names.join(', ')})"
+            raise "#{e.message}\n"\
+                  "Power off the listed VMs#{running} and re-run, or pass "\
+                  '--shift-ignore-running-vms to convert from a point-in-time snapshot '\
+                  'while they keep running (crash-consistent, not quiesced).'
         end
 
         puts "Waiting for Shift execution #{exec_id} to complete (Ctrl+C to abort)..."
@@ -4337,7 +4500,11 @@ GUESTFISH
             end
         end
 
-        if !@options[:delta]
+        # These guard virt-v2v reading the live VMDKs. Shift mode never touches
+        # them -- the disks were already converted on the storage side and are
+        # read from the NFS mount -- and Shift's own clone leaves a snapshot
+        # behind, which would trip the second check on every run.
+        if !@options[:delta] && !@options[:shift]
             # Some basic preliminary checks
             if @props['summary.runtime.powerState'] != 'poweredOff'
                 raise "Virtual Machine #{@options[:name]} is not Powered Off.".red

--- a/tests/netapp_shift_helper_test.rb
+++ b/tests/netapp_shift_helper_test.rb
@@ -1,0 +1,500 @@
+# Unit tests for NetAppShift::Helper (netapp_shift_helper.rb).
+#
+# Run with: ruby tests/netapp_shift_helper_test.rb
+#
+# netapp_shift_helper.rb has no OpenNebula dependencies, so unlike the
+# oneswap_helper tests no require shims are needed. Script-backed operations
+# are exercised against a stub interpreter that replays real upstream log
+# messages; REST reads are exercised against stubbed api_request responses.
+
+require 'minitest/autorun'
+require 'fileutils'
+require 'json'
+require 'logger'
+require 'tmpdir'
+
+require_relative '../netapp_shift_helper'
+
+# Timestamped log line in the upstream scripts' format
+def log_line(msg, level = 'INFO')
+    "2026-08-07 10:00:00,000 - Mod - #{level} - #{msg}"
+end
+
+QUIET = Logger.new(File::NULL)
+
+def quiet_helper(opts = {})
+    NetAppShift::Helper.new({ :server   => 'https://shift.local',
+                              :username => 'admin',
+                              :password => 's3cr3t',
+                              :logger   => QUIET }.merge(opts))
+end
+
+# Helper instance without running initialize, for parser-only tests
+def bare_helper
+    NetAppShift::Helper.allocate
+end
+
+class ParserTest < Minitest::Test
+
+    def parse(op, output)
+        bare_helper.send(:parse, op, output)
+    end
+
+    def test_get_site_ok
+        assert parse(:get_site, log_line('Site details fetched successfully'))[:ok]
+        refute parse(:get_site, log_line('Failed to fetch site details', 'ERROR'))[:ok]
+    end
+
+    def test_create_blueprint
+        out  = [log_line('Blueprint created with id: bp-123'),
+                log_line('Verified blueprint details: {}')].join("\n")
+        data = parse(:create_blueprint, out)
+
+        assert data[:ok]
+        assert_equal 'bp-123', data[:blueprint_id]
+        assert data[:verified]
+        refute parse(:create_blueprint, log_line('Blueprint creation failed', 'ERROR'))[:ok]
+    end
+
+    def test_compliance
+        out  = [log_line('Compliance check initiated with task id: task-9'),
+                log_line("Compliance check passed with result: [{'a': 1}]")].join("\n")
+        data = parse(:run_compliance_check, out)
+
+        assert data[:ok]
+        assert_equal 'task-9', data[:compliance_task_id]
+    end
+
+    def test_trigger_migration
+        data = parse(:trigger_migration,
+                     log_line('Migration triggered for blueprint bp_web with execution id: exec-77'))
+
+        assert data[:ok]
+        assert_equal 'exec-77', data[:execution_id]
+    end
+
+    def test_migration_status_complete
+        out  = [log_line('Status of Blueprint is convert_complete for blueprint bp-1'),
+                log_line('Job steps successfully completed for execution id exec-77')].join("\n")
+        data = parse(:check_migration_status, out)
+
+        assert data[:ok]
+        assert_equal 'convert_complete', data[:status]
+        assert data[:complete]
+        refute data[:running]
+    end
+
+    def test_migration_status_error
+        out  = [log_line('Status of Blueprint is convert_error for blueprint bp-1'),
+                log_line('Job step Convert disks is not successful', 'ERROR')].join("\n")
+        data = parse(:check_migration_status, out)
+
+        refute data[:ok]
+        refute data[:running]
+        assert_equal ['Convert disks'], data[:failed_steps]
+    end
+
+    def test_migration_status_python_gave_up_means_running
+        # verify_blueprint_status hit its ~20 min ceiling and returned False
+        data = parse(:check_migration_status,
+                     log_line('Status of Blueprint is False for blueprint bp-1'))
+
+        refute data[:ok]
+        refute data[:complete]
+        assert data[:running]
+    end
+
+    def test_migration_status_no_output_means_running
+        data = parse(:check_migration_status, '')
+
+        refute data[:ok]
+        assert data[:running]
+    end
+
+    def test_error_line_extraction
+        out = [log_line('all good'),
+               log_line('Failed to create blueprint, Response code is 500', 'ERROR'),
+               log_line('Failed to create blueprint, Response code is 500', 'ERROR')].join("\n")
+
+        errors = bare_helper.send(:error_lines, out)
+
+        assert_equal ['Failed to create blueprint, Response code is 500'], errors
+    end
+
+end
+
+class ConstructorTest < Minitest::Test
+
+    def test_bare_host_gets_https
+        assert_equal 'https://10.0.0.5', quiet_helper(:server => '10.0.0.5').server
+    end
+
+    def test_trailing_slash_stripped
+        assert_equal 'https://shift.local', quiet_helper(:server => 'https://shift.local/').server
+    end
+
+    def test_port_rejected
+        err = assert_raises(ArgumentError) { quiet_helper(:server => 'https://10.0.0.5:3700') }
+        assert_includes err.message, 'must not include a port'
+    end
+
+    def test_missing_credentials_rejected
+        assert_raises(ArgumentError) { quiet_helper(:username => '') }
+        assert_raises(ArgumentError) { quiet_helper(:password => '') }
+    end
+
+end
+
+class VmDetailTest < Minitest::Test
+
+    def test_minimal_conversion_fields
+        vm = NetAppShift::Helper.vm_detail(:name => 'web01',
+                                           :resource_group_name => 'rg1',
+                                           :boot_order => 2)
+
+        assert_equal({ 'name' => 'web01', 'boot_order' => 2,
+                       'resource_group_name' => 'rg1' }, vm)
+    end
+
+    def test_requires_name
+        assert_raises(ArgumentError) { NetAppShift::Helper.vm_detail({}) }
+    end
+
+end
+
+class ConvertedDisksTest < Minitest::Test
+
+    def test_single_disk
+        Dir.mktmpdir do |mount|
+            File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+            assert_equal [File.join(mount, 'web01.qcow2')],
+                         bare_helper.converted_disks('web01', mount, 1)
+        end
+    end
+
+    def test_multi_disk_ordering
+        Dir.mktmpdir do |mount|
+            # Shift naming observed on hardware: base, _1, _2
+            ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'].each do |f|
+                File.write(File.join(mount, f), 'x')
+            end
+
+            disks = bare_helper.converted_disks('multi', mount, 3)
+
+            assert_equal ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'],
+                         disks.map {|d| File.basename(d) }
+        end
+    end
+
+    def test_missing_disks_named_in_error
+        Dir.mktmpdir do |mount|
+            File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+            err = assert_raises(NetAppShift::Error) do
+                bare_helper.converted_disks('web01', mount, 2)
+            end
+
+            assert_includes err.message, 'web01_1.qcow2'
+            refute_includes err.message, "web01.qcow2,"
+        end
+    end
+
+    def test_does_not_glob_similar_names
+        Dir.mktmpdir do |mount|
+            # A neighboring VM whose name shares the prefix must not satisfy
+            # the check for the missing disk.
+            File.write(File.join(mount, 'web01-old.qcow2'), 'x')
+
+            assert_raises(NetAppShift::Error) do
+                bare_helper.converted_disks('web01', mount, 1)
+            end
+        end
+    end
+
+    def test_rejects_non_positive_count
+        assert_raises(ArgumentError) { bare_helper.converted_disks('web01', '/mnt', 0) }
+    end
+
+end
+
+class WaitForCompletionTest < Minitest::Test
+
+    def make_result(data)
+        NetAppShift::Result.new(:check_migration_status, :data => data, :duration => 0.1)
+    end
+
+    # Helper whose check_migration_status replays canned results
+    def waiting_helper(results)
+        helper = quiet_helper
+        queue  = results.dup
+        helper.define_singleton_method(:check_migration_status) do |_bp, _exec|
+            queue.shift || raise('check_migration_status called too many times')
+        end
+        helper.define_singleton_method(:sleep_between_polls) { nil }
+        helper
+    end
+
+    def ok_result
+        make_result(:ok => true, :status => 'convert_complete', :complete => true,
+                    :running => false, :jobs_ok => true)
+    end
+
+    def running_result
+        make_result(:ok => false, :status => 'False', :complete => false, :running => true)
+    end
+
+    def error_result
+        make_result(:ok => false, :status => 'convert_error', :complete => false,
+                    :running => false)
+    end
+
+    def test_returns_terminal_ok_result
+        helper = waiting_helper([ok_result])
+
+        result = helper.wait_for_completion('bp', 'exec-1')
+
+        assert result.ok?
+        assert_equal 'convert_complete', result[:status]
+    end
+
+    def test_loops_past_python_polling_ceiling
+        helper = waiting_helper([running_result, running_result, ok_result])
+
+        helper.stub(:sleep, nil) do
+            assert helper.wait_for_completion('bp', 'exec-1').ok?
+        end
+    end
+
+    def test_raises_on_error_status
+        helper = waiting_helper([error_result])
+
+        assert_raises(NetAppShift::OperationError) do
+            helper.wait_for_completion('bp', 'exec-1')
+        end
+    end
+
+    def test_raises_on_complete_with_failed_jobs
+        helper = waiting_helper([make_result(:ok => false, :status => 'convert_complete',
+                                             :complete => true, :running => false,
+                                             :jobs_ok => false)])
+
+        assert_raises(NetAppShift::OperationError) do
+            helper.wait_for_completion('bp', 'exec-1')
+        end
+    end
+
+    def test_overall_timeout
+        helper = waiting_helper([running_result, running_result, running_result])
+
+        helper.stub(:sleep, nil) do
+            err = assert_raises(NetAppShift::OperationError) do
+                # An already-expired deadline: the first still-running result
+                # must trip the overall timeout rather than polling again.
+                helper.wait_for_completion('bp', 'exec-1', :timeout => 1e-9)
+            end
+
+            assert_includes err.message, 'Timed out'
+        end
+    end
+
+    def test_nil_timeout_keeps_waiting
+        helper = waiting_helper([running_result] * 5 + [ok_result])
+
+        helper.stub(:sleep, nil) do
+            assert helper.wait_for_completion('bp', 'exec-1', :timeout => nil).ok?
+        end
+    end
+
+end
+
+class BlueprintVmNamesTest < Minitest::Test
+
+    BLUEPRINTS = {
+        'list' => [
+            { '_id' => 'bp-1', 'name' => 'bp_web',
+              'protectionGroups' => [{ '_id' => 'rg-1' }] },
+            { '_id' => 'bp-2', 'name' => 'bp_all',
+              'protectionGroups' => [{ '_id' => 'rg-1' }, { '_id' => 'rg-2' }] }
+        ]
+    }.freeze
+
+    GROUPS = {
+        'list' => [
+            { '_id' => 'rg-1', 'name' => 'group1',
+              'vms' => [{ '_id' => 'vm-1', 'name' => 'web01' },
+                        { '_id' => 'vm-2', 'name' => 'web02' }] },
+            { '_id' => 'rg-2', 'name' => 'group2',
+              'vms' => [{ '_id' => 'vm-3', 'name' => 'db01' }] },
+            { '_id' => 'rg-9', 'name' => 'unrelated',
+              'vms' => [{ '_id' => 'vm-9', 'name' => 'other' }] }
+        ]
+    }.freeze
+
+    # Helper whose api_request replays canned appliance responses
+    def rest_helper
+        helper = quiet_helper
+        calls  = []
+        helper.define_singleton_method(:api_request) do |_method, _port, path, **_kw|
+            calls << path
+            case path
+            when '/api/tenant/session'     then { 'session' => { '_id' => 'sid-1' } }
+            when '/api/tenant/session/end' then {}
+            when '/api/setup/drplan'          then BLUEPRINTS
+            when '/api/setup/protectionGroup' then GROUPS
+            else raise "unexpected path #{path}"
+            end
+        end
+        [helper, calls]
+    end
+
+    def test_single_group
+        helper, = rest_helper
+
+        assert_equal %w[web01 web02], helper.blueprint_vm_names('bp_web')
+    end
+
+    def test_multiple_groups_in_order
+        helper, = rest_helper
+
+        assert_equal %w[web01 web02 db01], helper.blueprint_vm_names('bp_all')
+    end
+
+    def test_unknown_blueprint_lists_available
+        helper, = rest_helper
+
+        err = assert_raises(NetAppShift::OperationError) do
+            helper.blueprint_vm_names('nope')
+        end
+
+        assert_includes err.message, 'bp_web'
+        assert_includes err.message, 'bp_all'
+    end
+
+    def test_session_always_ended
+        helper, calls = rest_helper
+
+        helper.blueprint_vm_names('bp_web')
+        assert_includes calls, '/api/tenant/session/end'
+
+        calls.clear
+        assert_raises(NetAppShift::OperationError) { helper.blueprint_vm_names('nope') }
+        assert_includes calls, '/api/tenant/session/end'
+    end
+
+end
+
+class ScriptPlumbingTest < Minitest::Test
+
+    # Build a fake script dir + interpreter that echoes the payload it was
+    # given and replays a realistic success log to stderr (where Python
+    # logging writes).
+    def with_stub_env
+        Dir.mktmpdir do |dir|
+            script_dir = File.join(dir, 'Python')
+            FileUtils.mkdir_p(script_dir)
+
+            NetAppShift::Helper::OPERATIONS.each_value do |name|
+                File.write(File.join(script_dir, "#{name}.py"), "# stub\n")
+                File.write(File.join(script_dir, "#{name}.json"),
+                           %({"executions": [{"execution_name": ""}]}\n))
+                File.chmod(0o644, File.join(script_dir, "#{name}.json"))
+            end
+
+            stub = File.join(dir, 'fakepython')
+            File.write(stub, <<~SH)
+              #!/bin/bash
+              if [ "$1" = "-c" ]; then exit 0; fi
+              base="${1%.py}"
+              cp "$base.json" "#{dir}/seen-$base.json"
+              case "$base" in
+                trigger_migration)
+                  echo "#{log_line('Migration triggered for blueprint bp with execution id: ex-42')}" >&2 ;;
+                check_migration_status)
+                  echo "#{log_line('Status of Blueprint is convert_complete for blueprint bp-abc')}" >&2
+                  echo "#{log_line('Job steps successfully completed for execution id ex-42')}" >&2 ;;
+              esac
+              exit 0
+            SH
+            FileUtils.chmod(0o755, stub)
+
+            helper = quiet_helper(:script_dir => script_dir, :python => stub)
+
+            yield helper, script_dir, dir
+        end
+    end
+
+    def test_trigger_runs_and_parses
+        with_stub_env do |helper, _script_dir, dir|
+            result = helper.trigger_migration('bp')
+
+            assert result.ok?
+            assert_equal 'ex-42', result[:execution_id]
+            assert_equal 0, result.exit_code
+
+            seen = JSON.parse(File.read(File.join(dir, 'seen-trigger_migration.json')))
+            exec = seen['executions'].first
+
+            assert_equal 'admin', exec['shift_username']
+            assert_equal 's3cr3t', exec['shift_password']
+            assert_equal 'https://shift.local', exec['shift_server_ip']
+            assert_equal 'bp', exec['blueprint_name']
+            assert_equal 'clone_based_conversion', exec['migration_mode']
+        end
+    end
+
+    def test_payload_file_restored_with_mode
+        with_stub_env do |helper, script_dir, _dir|
+            original = File.join(script_dir, 'trigger_migration.json')
+
+            helper.trigger_migration('bp')
+
+            assert_equal({ 'execution_name' => '' },
+                         JSON.parse(File.read(original))['executions'].first)
+            assert_equal '644', format('%o', File.stat(original).mode & 0o777)
+        end
+    end
+
+    def test_check_migration_status_passes_execution_id
+        with_stub_env do |helper, _script_dir, dir|
+            result = helper.check_migration_status('bp', 'ex-42')
+
+            assert result.ok?
+
+            seen = JSON.parse(File.read(File.join(dir, 'seen-check_migration_status.json')))
+
+            assert_equal 'ex-42', seen['executions'].first['execution_id']
+        end
+    end
+
+    def test_check_bang_raises_with_last_error
+        with_stub_env do |helper, _script_dir, _dir|
+            # get_site stub logs nothing -> no success message
+            err = assert_raises(NetAppShift::OperationError) do
+                helper.check!(helper.get_site)
+            end
+
+            assert_includes err.message, 'get_site'
+        end
+    end
+
+    def test_missing_script_dir_raises_dependency_error
+        helper = quiet_helper(:script_dir => '/nonexistent/shift')
+
+        err = assert_raises(NetAppShift::DependencyError) { helper.get_site }
+        assert_includes err.message, 'submodule'
+    end
+
+    def test_dry_run_skips_python_and_redacts
+        helper = quiet_helper(:script_dir => '/nonexistent', :dry_run => true)
+
+        assert helper.get_site.ok?
+        assert helper.get_site[:dry_run]
+
+        redacted = helper.send(:redact, helper.send(:base_execution))
+
+        assert_equal '[redacted]', redacted['shift_password']
+        assert_equal 'admin', redacted['shift_username']
+    end
+
+end

--- a/tests/netapp_shift_helper_test.rb
+++ b/tests/netapp_shift_helper_test.rb
@@ -166,6 +166,39 @@ class BlueprintVmNamesTest < Minitest::Test
         assert_includes fake.paths, '/api/tenant/session/end'
     end
 
+    def test_blueprint_vms_carry_their_resource_group
+        helper, = helper_with(SETUP_ROUTES)
+
+        assert_equal [{ :name => 'web01', :id => 'vm-1', :resource_group => 'group1' },
+                      { :name => 'web02', :id => 'vm-2', :resource_group => 'group1' },
+                      { :name => 'db01',  :id => 'vm-3', :resource_group => 'group2' }],
+                     helper.blueprint_vms('waves')
+    end
+
+    def test_blueprint_summaries_join_groups_and_vms
+        helper, = helper_with(SETUP_ROUTES)
+        summaries = helper.blueprint_summaries
+
+        assert_equal %w[multidisk waves], summaries.map {|bp| bp[:name] }
+
+        waves = summaries.find {|bp| bp[:name] == 'waves' }
+        assert_equal %w[group1 group2], waves[:resource_groups]
+        assert_equal %w[web01 web02 db01], waves[:vms]
+
+        # the unrelated group is not attached to any blueprint
+        refute_includes summaries.flat_map {|bp| bp[:vms] }, 'other'
+    end
+
+    def test_blueprint_summaries_survive_a_dangling_group_reference
+        blueprints = { 'list' => [{ '_id' => 'bp-x', 'name' => 'stale',
+                                    'protectionGroups' => [{ '_id' => 'gone' }] }] }
+        helper, = helper_with(SETUP_ROUTES.merge('/api/setup/drplan' => blueprints))
+
+        assert_equal [{ :name => 'stale', :id => 'bp-x',
+                        :resource_groups => [], :vms => [] }],
+                     helper.blueprint_summaries
+    end
+
     def test_session_is_reused_not_reopened
         helper, fake = helper_with(SETUP_ROUTES)
         helper.blueprint_vm_names('multidisk')
@@ -179,37 +212,38 @@ end
 
 class BlueprintExecutionStateTest < Minitest::Test
 
-    def entry(recovery_status, exec_id = 'ex-1', bp_id = 'bp-1')
-        { 'drPlan'        => { '_id' => bp_id, 'recoveryStatus' => recovery_status },
-          'lastExecution' => { '_id' => exec_id } }
+    # Verbatim shape from a live appliance. Note there is no "recoveryStatus"
+    # on drPlan -- the state lives on lastExecution.
+    def entry(exec_status, exec_id = 'ex-1', bp_id = 'bp-1', type = 'convert')
+        {
+            'drPlan'        => { '_id' => bp_id, 'name' => 'multidisk',
+                                 'activeSite' => 'source', 'vmSuccessCount' => 0 },
+            'lastExecution' => exec_status.nil? ? nil : { '_id' => exec_id,
+                                                          'status' => exec_status,
+                                                          'type' => type },
+            'lastPrepareVmExecution' => nil
+        }
     end
 
     def state_helper(status_body)
-        helper_with(SETUP_ROUTES.merge('/api/recovery/drplan/status' => status_body))
+        helper_with(SETUP_ROUTES.merge(NetAppShift::Helper::PATH_BLUEPRINT_STATUS => status_body))
     end
 
     def test_completed_conversion
-        helper, fake = state_helper([entry('convert_complete')])
+        helper, fake = state_helper([entry(NetAppShift::Helper::STATE_SUCCESS)])
         state = helper.blueprint_execution_state('multidisk')
 
         assert state[:complete]
         refute state[:running]
         refute state[:failed]
         assert_equal 'ex-1', state[:execution_id]
+        assert_equal 'convert', state[:type]
         assert_equal NetAppShift::Helper::RECOVERY_PORT,
-                     fake.find('/api/recovery/drplan/status')[:port]
-    end
-
-    def test_running_execution
-        helper, = state_helper([entry('convert_inprogress')])
-        state = helper.blueprint_execution_state('multidisk')
-
-        assert state[:running]
-        refute state[:complete]
+                     fake.find(NetAppShift::Helper::PATH_BLUEPRINT_STATUS)[:port]
     end
 
     def test_failed_execution
-        helper, = state_helper([entry('convert_error')])
+        helper, = state_helper([entry(NetAppShift::Helper::STATE_FAILED)])
         state = helper.blueprint_execution_state('multidisk')
 
         assert state[:failed]
@@ -217,13 +251,23 @@ class BlueprintExecutionStateTest < Minitest::Test
         refute state[:running]
     end
 
-    def test_absent_blueprint_returns_nil
-        helper, = state_helper([entry('convert_complete', 'ex-9', 'bp-other')])
+    def test_in_flight_execution_is_running
+        helper, = state_helper([entry(2)])
+        state = helper.blueprint_execution_state('multidisk')
+
+        assert state[:running]
+        refute state[:complete]
+        refute state[:failed]
+        assert_equal 'ex-1', state[:execution_id]
+    end
+
+    def test_never_executed_returns_nil
+        helper, = state_helper([entry(nil)])
         assert_nil helper.blueprint_execution_state('multidisk')
     end
 
-    def test_empty_status_returns_nil
-        helper, = state_helper([entry('')])
+    def test_absent_blueprint_returns_nil
+        helper, = state_helper([entry(NetAppShift::Helper::STATE_SUCCESS, 'ex-9', 'bp-other')])
         assert_nil helper.blueprint_execution_state('multidisk')
     end
 
@@ -233,12 +277,12 @@ class BlueprintExecutionStateTest < Minitest::Test
     end
 
     def test_tolerates_list_envelope
-        helper, = state_helper('list' => [entry('convert_complete')])
+        helper, = state_helper('list' => [entry(NetAppShift::Helper::STATE_SUCCESS)])
         assert helper.blueprint_execution_state('multidisk')[:complete]
     end
 
     def test_tolerates_junk_entries
-        helper, = state_helper(['nonsense', nil, entry('convert_complete')])
+        helper, = state_helper(['nonsense', nil, entry(NetAppShift::Helper::STATE_SUCCESS)])
         assert helper.blueprint_execution_state('multidisk')[:complete]
     end
 
@@ -246,8 +290,8 @@ end
 
 class ExecutionStatusTest < Minitest::Test
 
-    S = NetAppShift::Helper::STEP_SUCCESS
-    F = NetAppShift::Helper::STEP_FAILED
+    S = NetAppShift::Helper::STATE_SUCCESS
+    F = NetAppShift::Helper::STATE_FAILED
 
     def status_for(body)
         helper, = helper_with(%r{/api/recovery/execution/.*/steps} => body)
@@ -281,8 +325,8 @@ end
 
 class WaitForCompletionTest < Minitest::Test
 
-    S = NetAppShift::Helper::STEP_SUCCESS
-    F = NetAppShift::Helper::STEP_FAILED
+    S = NetAppShift::Helper::STATE_SUCCESS
+    F = NetAppShift::Helper::STATE_FAILED
 
     def waiter(*bodies)
         helper_with(%r{/api/recovery/execution/.*/steps} => sequence(*bodies))
@@ -411,11 +455,20 @@ class TriggerConversionTest < Minitest::Test
                      fake.find('/execution')[:body]['serviceAccounts'])
     end
 
-    def test_migrate_mode_uses_the_migrate_path
+    # The default request must stay exactly as it is today; the override is
+    # only sent when explicitly asked for.
+    def test_powered_on_override_is_absent_by_default
         helper, fake = trigger_helper('_id' => 'ex-77')
-        helper.trigger_conversion('multidisk', NetAppShift::Helper::MIGRATION)
+        helper.trigger_conversion('multidisk')
 
-        assert_includes fake.paths, '/api/recovery/drPlan/bp-1/migrate/execution'
+        refute fake.find('/execution')[:body].key?('ignorePoweredOnVms')
+    end
+
+    def test_powered_on_override_is_sent_when_requested
+        helper, fake = trigger_helper('_id' => 'ex-77')
+        helper.trigger_conversion('multidisk', :ignore_powered_on => true)
+
+        assert_equal true, fake.find('/execution')[:body]['ignorePoweredOnVms']
     end
 
     def test_finds_a_nested_execution_id
@@ -474,6 +527,45 @@ class ApiErrorTranslationTest < Minitest::Test
         body = { 'message' => 'No further execution is allowed.' }
 
         assert_raises(NetAppShift::AlreadyExecuted) { raise_for('500', JSON.generate(body)) }
+    end
+
+    # Verbatim from a live appliance. Note the top-level message is their
+    # "[object Object]" bug, and the VM names live in a *second* error object.
+    ERSCSTEX022_BODY = {
+        'level'   => 'error',
+        'message' => '[object Object]',
+        'errors'  => [
+            {
+                'uid'     => 'c268a134-68f0-4fda-b22d-64731cd4df48',
+                'code'    => 'ERSCSTEX022',
+                'message' => "ERSCSTEX022: Cannot execute the 'convert' action - as some " \
+                             'VMs are still powered on. Powered on VMs - ' \
+                             'u2505-oneswap-test_netappshift,oneswap-shift-multidisk',
+                'level'   => 'error'
+            },
+            {
+                'executionType'     => 'convert',
+                'poweredOnVmNames'  => ['u2505-oneswap-test_netappshift',
+                                        'oneswap-shift-multidisk'],
+                'poweredOffVmNames' => [],
+                'code'              => '',
+                'message'           => '[object Object]'
+            }
+        ]
+    }.freeze
+
+    def test_powered_on_vms_is_its_own_error_carrying_the_names
+        err = assert_raises(NetAppShift::PoweredOnVms) do
+            raise_for('500', JSON.generate(ERSCSTEX022_BODY))
+        end
+
+        assert_equal 'ERSCSTEX022', err.code
+        assert_equal 500, err.http_status
+        assert_equal ['u2505-oneswap-test_netappshift', 'oneswap-shift-multidisk'],
+                     err.vm_names
+        # the readable message, not the "[object Object]" top-level one
+        assert_includes err.message, 'still powered on'
+        refute_includes err.message, '[object Object]'
     end
 
     def test_other_errors_surface_the_appliance_message

--- a/tests/netapp_shift_helper_test.rb
+++ b/tests/netapp_shift_helper_test.rb
@@ -71,6 +71,34 @@ class ParserTest < Minitest::Test
 
         assert data[:ok]
         assert_equal 'exec-77', data[:execution_id]
+        refute data[:already_executed]
+    end
+
+    # Shift refuses a second execution of an already-converted blueprint.
+    # Verbatim body from a real appliance (note their "succesful" typo -- do
+    # not match on it).
+    ERSCSTEX009 = log_line(
+        'Failed to execute blueprint 588314a3-1a5c-4b26-9cbd-cc8c7b394e36 with mode ' \
+        'clone_based_conversion, Response code is 500, response message is ' \
+        '{"level":"error","message":"ERSCSTEX009: The -convert execution is succesful ' \
+        'for Blueprint - 588314a3-1a5c-4b26-9cbd-cc8c7b394e36. No further execution ' \
+        'is allowed.","errors":[]}', 'ERROR'
+    ).freeze
+
+    def test_trigger_migration_detects_already_executed
+        data = parse(:trigger_migration, ERSCSTEX009)
+
+        assert data[:already_executed]
+        refute data[:ok]
+        assert_nil data[:execution_id]
+    end
+
+    def test_other_trigger_failures_are_not_already_executed
+        data = parse(:trigger_migration,
+                     log_line('Failed to execute blueprint bp-1, Response code is 401', 'ERROR'))
+
+        refute data[:already_executed]
+        refute data[:ok]
     end
 
     def test_migration_status_complete
@@ -119,6 +147,58 @@ class ParserTest < Minitest::Test
         errors = bare_helper.send(:error_lines, out)
 
         assert_equal ['Failed to create blueprint, Response code is 500'], errors
+    end
+
+end
+
+class CheckBangErrorSelectionTest < Minitest::Test
+
+    # A real trigger_migration failure: blueprint.py logs the HTTP status and
+    # body first, trigger_migration.py appends two generic trailers.
+    TRIGGER_FAILURE = [
+        log_line('Failed to execute blueprint bp-1 with mode clone_based_conversion, ' \
+                 'Response code is 400, response message is {"error":"already executed"}',
+                 'ERROR'),
+        log_line('Triggering Migration operation for blueprint multidisk was not ' \
+                 'successful using POST run compliance API', 'ERROR'),
+        log_line('Migration trigger failed for migration index 1', 'ERROR')
+    ].join("\n").freeze
+
+    def failing_result(output)
+        NetAppShift::Result.new(:trigger_migration,
+                                :output   => output,
+                                :errors   => bare_helper.send(:error_lines, output),
+                                :data     => { :ok => false },
+                                :duration => 1.0)
+    end
+
+    def test_prefers_the_line_with_the_http_status
+        err = assert_raises(NetAppShift::OperationError) do
+            bare_helper.check!(failing_result(TRIGGER_FAILURE))
+        end
+
+        assert_includes err.message, 'Response code is 400'
+        assert_includes err.message, 'already executed'
+        refute_includes err.message, 'migration index 1'
+    end
+
+    def test_falls_back_to_first_error_without_a_status_line
+        output = [log_line('Something broke', 'ERROR'),
+                  log_line('Migration trigger failed for migration index 1', 'ERROR')].join("\n")
+
+        err = assert_raises(NetAppShift::OperationError) do
+            bare_helper.check!(failing_result(output))
+        end
+
+        assert_includes err.message, 'Something broke'
+    end
+
+    def test_falls_back_to_generic_message_without_errors
+        err = assert_raises(NetAppShift::OperationError) do
+            bare_helper.check!(failing_result(log_line('nothing useful')))
+        end
+
+        assert_includes err.message, 'no success message'
     end
 
 end
@@ -380,6 +460,104 @@ class BlueprintVmNamesTest < Minitest::Test
         calls.clear
         assert_raises(NetAppShift::OperationError) { helper.blueprint_vm_names('nope') }
         assert_includes calls, '/api/tenant/session/end'
+    end
+
+end
+
+class BlueprintExecutionStateTest < Minitest::Test
+
+    BLUEPRINTS = {
+        'list' => [{ '_id' => 'bp-1', 'name' => 'multidisk', 'protectionGroups' => [] }]
+    }.freeze
+
+    # Helper whose api_request replays a canned /api/recovery/drplan/status
+    def state_helper(status_body)
+        helper = quiet_helper
+        ports  = []
+        helper.define_singleton_method(:api_request) do |_method, port, path, **_kw|
+            ports << [port, path]
+            case path
+            when '/api/tenant/session'          then { 'session' => { '_id' => 'sid-1' } }
+            when '/api/tenant/session/end'      then {}
+            when '/api/setup/drplan'            then BLUEPRINTS
+            when '/api/recovery/drplan/status'  then status_body
+            else raise "unexpected path #{path}"
+            end
+        end
+        [helper, ports]
+    end
+
+    def entry(recovery_status, exec_id = 'ex-1', bp_id = 'bp-1')
+        { 'drPlan'        => { '_id' => bp_id, 'recoveryStatus' => recovery_status },
+          'lastExecution' => { '_id' => exec_id, 'status' => 4 } }
+    end
+
+    def test_completed_conversion
+        helper, ports = state_helper([entry('convert_complete')])
+
+        state = helper.blueprint_execution_state('multidisk')
+
+        assert state[:complete]
+        refute state[:running]
+        refute state[:failed]
+        assert_equal 'convert_complete', state[:status]
+        assert_equal 'ex-1', state[:execution_id]
+
+        # must query the recovery service, not the setup service
+        assert_includes ports, [NetAppShift::Helper::RECOVERY_PORT,
+                                '/api/recovery/drplan/status']
+    end
+
+    def test_running_execution
+        helper, = state_helper([entry('convert_inprogress')])
+
+        state = helper.blueprint_execution_state('multidisk')
+
+        assert state[:running]
+        refute state[:complete]
+        assert_equal 'ex-1', state[:execution_id]
+    end
+
+    def test_failed_execution
+        helper, = state_helper([entry('convert_error')])
+
+        state = helper.blueprint_execution_state('multidisk')
+
+        assert state[:failed]
+        refute state[:complete]
+        refute state[:running]
+    end
+
+    def test_never_run_returns_nil
+        # blueprint absent from the status list entirely
+        helper, = state_helper([entry('convert_complete', 'ex-9', 'bp-other')])
+
+        assert_nil helper.blueprint_execution_state('multidisk')
+    end
+
+    def test_empty_status_returns_nil
+        helper, = state_helper([entry('')])
+
+        assert_nil helper.blueprint_execution_state('multidisk')
+    end
+
+    def test_empty_status_list_returns_nil
+        helper, = state_helper([])
+
+        assert_nil helper.blueprint_execution_state('multidisk')
+    end
+
+    # Some appliances may wrap the collection the way the setup service does
+    def test_tolerates_list_envelope
+        helper, = state_helper('list' => [entry('convert_complete')])
+
+        assert helper.blueprint_execution_state('multidisk')[:complete]
+    end
+
+    def test_tolerates_junk_entries
+        helper, = state_helper(['nonsense', nil, entry('convert_complete')])
+
+        assert helper.blueprint_execution_state('multidisk')[:complete]
     end
 
 end

--- a/tests/netapp_shift_helper_test.rb
+++ b/tests/netapp_shift_helper_test.rb
@@ -3,524 +3,213 @@
 # Run with: ruby tests/netapp_shift_helper_test.rb
 #
 # netapp_shift_helper.rb has no OpenNebula dependencies, so unlike the
-# oneswap_helper tests no require shims are needed. Script-backed operations
-# are exercised against a stub interpreter that replays real upstream log
-# messages; REST reads are exercised against stubbed api_request responses.
+# oneswap_helper tests no require shims are needed. The appliance is faked at
+# the single transport chokepoint (#api_request), which exercises every
+# endpoint path, payload and response-handling decision above it.
 
 require 'minitest/autorun'
-require 'fileutils'
 require 'json'
 require 'logger'
 require 'tmpdir'
 
 require_relative '../netapp_shift_helper'
 
-# Timestamped log line in the upstream scripts' format
-def log_line(msg, level = 'INFO')
-    "2026-08-07 10:00:00,000 - Mod - #{level} - #{msg}"
-end
-
 QUIET = Logger.new(File::NULL)
 
-def quiet_helper(opts = {})
-    NetAppShift::Helper.new({ :server   => 'https://shift.local',
-                              :username => 'admin',
-                              :password => 's3cr3t',
-                              :logger   => QUIET }.merge(opts))
-end
+# Records every request and replays canned responses. Routes are keyed by
+# path (String for exact match, Regexp otherwise); a callable route is invoked
+# per request so a sequence of differing responses can be replayed.
+class FakeAppliance
 
-# Helper instance without running initialize, for parser-only tests
-def bare_helper
-    NetAppShift::Helper.allocate
-end
+    SESSION = {
+        '/api/tenant/session'     => { 'session' => { '_id' => 'sid-1' } },
+        '/api/tenant/session/end' => {}
+    }.freeze
 
-class ParserTest < Minitest::Test
+    attr_reader :calls
 
-    def parse(op, output)
-        bare_helper.send(:parse, op, output)
+    def initialize(routes = {})
+        @routes = SESSION.merge(routes)
+        @calls  = []
     end
 
-    def test_get_site_ok
-        assert parse(:get_site, log_line('Site details fetched successfully'))[:ok]
-        refute parse(:get_site, log_line('Failed to fetch site details', 'ERROR'))[:ok]
+    def handle(method_class, port, path, body: nil, session: nil, timeout: nil)
+        @calls << { :verb => method_class::METHOD, :port => port, :path => path,
+                    :body => body, :session => session, :timeout => timeout }
+
+        key = @routes.keys.find {|k| k.is_a?(Regexp) ? path.match?(k) : k == path }
+
+        raise "test: unrouted #{method_class::METHOD} #{path}" if key.nil?
+
+        route = @routes[key]
+        route.respond_to?(:call) ? route.call : route
     end
 
-    def test_create_blueprint
-        out  = [log_line('Blueprint created with id: bp-123'),
-                log_line('Verified blueprint details: {}')].join("\n")
-        data = parse(:create_blueprint, out)
-
-        assert data[:ok]
-        assert_equal 'bp-123', data[:blueprint_id]
-        assert data[:verified]
-        refute parse(:create_blueprint, log_line('Blueprint creation failed', 'ERROR'))[:ok]
+    def paths(verb = nil)
+        @calls.select {|c| verb.nil? || c[:verb] == verb }.map {|c| c[:path] }
     end
 
-    def test_compliance
-        out  = [log_line('Compliance check initiated with task id: task-9'),
-                log_line("Compliance check passed with result: [{'a': 1}]")].join("\n")
-        data = parse(:run_compliance_check, out)
-
-        assert data[:ok]
-        assert_equal 'task-9', data[:compliance_task_id]
-    end
-
-    def test_trigger_migration
-        data = parse(:trigger_migration,
-                     log_line('Migration triggered for blueprint bp_web with execution id: exec-77'))
-
-        assert data[:ok]
-        assert_equal 'exec-77', data[:execution_id]
-        refute data[:already_executed]
-    end
-
-    # Shift refuses a second execution of an already-converted blueprint.
-    # Verbatim body from a real appliance (note their "succesful" typo -- do
-    # not match on it).
-    ERSCSTEX009 = log_line(
-        'Failed to execute blueprint 588314a3-1a5c-4b26-9cbd-cc8c7b394e36 with mode ' \
-        'clone_based_conversion, Response code is 500, response message is ' \
-        '{"level":"error","message":"ERSCSTEX009: The -convert execution is succesful ' \
-        'for Blueprint - 588314a3-1a5c-4b26-9cbd-cc8c7b394e36. No further execution ' \
-        'is allowed.","errors":[]}', 'ERROR'
-    ).freeze
-
-    def test_trigger_migration_detects_already_executed
-        data = parse(:trigger_migration, ERSCSTEX009)
-
-        assert data[:already_executed]
-        refute data[:ok]
-        assert_nil data[:execution_id]
-    end
-
-    def test_other_trigger_failures_are_not_already_executed
-        data = parse(:trigger_migration,
-                     log_line('Failed to execute blueprint bp-1, Response code is 401', 'ERROR'))
-
-        refute data[:already_executed]
-        refute data[:ok]
-    end
-
-    def test_migration_status_complete
-        out  = [log_line('Status of Blueprint is convert_complete for blueprint bp-1'),
-                log_line('Job steps successfully completed for execution id exec-77')].join("\n")
-        data = parse(:check_migration_status, out)
-
-        assert data[:ok]
-        assert_equal 'convert_complete', data[:status]
-        assert data[:complete]
-        refute data[:running]
-    end
-
-    def test_migration_status_error
-        out  = [log_line('Status of Blueprint is convert_error for blueprint bp-1'),
-                log_line('Job step Convert disks is not successful', 'ERROR')].join("\n")
-        data = parse(:check_migration_status, out)
-
-        refute data[:ok]
-        refute data[:running]
-        assert_equal ['Convert disks'], data[:failed_steps]
-    end
-
-    def test_migration_status_python_gave_up_means_running
-        # verify_blueprint_status hit its ~20 min ceiling and returned False
-        data = parse(:check_migration_status,
-                     log_line('Status of Blueprint is False for blueprint bp-1'))
-
-        refute data[:ok]
-        refute data[:complete]
-        assert data[:running]
-    end
-
-    def test_migration_status_no_output_means_running
-        data = parse(:check_migration_status, '')
-
-        refute data[:ok]
-        assert data[:running]
-    end
-
-    def test_error_line_extraction
-        out = [log_line('all good'),
-               log_line('Failed to create blueprint, Response code is 500', 'ERROR'),
-               log_line('Failed to create blueprint, Response code is 500', 'ERROR')].join("\n")
-
-        errors = bare_helper.send(:error_lines, out)
-
-        assert_equal ['Failed to create blueprint, Response code is 500'], errors
+    def find(path_fragment)
+        @calls.find {|c| c[:path].include?(path_fragment) }
     end
 
 end
 
-class CheckBangErrorSelectionTest < Minitest::Test
+# Replays the given responses in order, repeating the last one forever.
+def sequence(*responses)
+    queue = responses.dup
+    -> { queue.length > 1 ? queue.shift : queue.first }
+end
 
-    # A real trigger_migration failure: blueprint.py logs the HTTP status and
-    # body first, trigger_migration.py appends two generic trailers.
-    TRIGGER_FAILURE = [
-        log_line('Failed to execute blueprint bp-1 with mode clone_based_conversion, ' \
-                 'Response code is 400, response message is {"error":"already executed"}',
-                 'ERROR'),
-        log_line('Triggering Migration operation for blueprint multidisk was not ' \
-                 'successful using POST run compliance API', 'ERROR'),
-        log_line('Migration trigger failed for migration index 1', 'ERROR')
-    ].join("\n").freeze
+def helper_with(routes = {}, options = {})
+    helper = NetAppShift::Helper.new({ :server   => 'https://shift.local',
+                                       :username => 'admin',
+                                       :password => 's3cr3t',
+                                       :logger   => QUIET }.merge(options))
+    fake = FakeAppliance.new(routes)
 
-    def failing_result(output)
-        NetAppShift::Result.new(:trigger_migration,
-                                :output   => output,
-                                :errors   => bare_helper.send(:error_lines, output),
-                                :data     => { :ok => false },
-                                :duration => 1.0)
+    helper.define_singleton_method(:api_request) do |mc, port, path, **kw|
+        fake.handle(mc, port, path, **kw)
     end
+    # never actually wait in tests
+    helper.define_singleton_method(:sleep) {|*| nil }
 
-    def test_prefers_the_line_with_the_http_status
-        err = assert_raises(NetAppShift::OperationError) do
-            bare_helper.check!(failing_result(TRIGGER_FAILURE))
-        end
+    [helper, fake]
+end
 
-        assert_includes err.message, 'Response code is 400'
-        assert_includes err.message, 'already executed'
-        refute_includes err.message, 'migration index 1'
-    end
+BLUEPRINTS = {
+    'list' => [
+        { '_id' => 'bp-1', 'name' => 'multidisk', 'protectionGroups' => [{ '_id' => 'rg-1' }] },
+        { '_id' => 'bp-2', 'name' => 'waves',
+          'protectionGroups' => [{ '_id' => 'rg-1' }, { '_id' => 'rg-2' }] }
+    ]
+}.freeze
 
-    def test_falls_back_to_first_error_without_a_status_line
-        output = [log_line('Something broke', 'ERROR'),
-                  log_line('Migration trigger failed for migration index 1', 'ERROR')].join("\n")
+GROUPS = {
+    'list' => [
+        { '_id' => 'rg-1', 'name' => 'group1',
+          'vms' => [{ '_id' => 'vm-1', 'name' => 'web01' },
+                    { '_id' => 'vm-2', 'name' => 'web02' }] },
+        { '_id' => 'rg-2', 'name' => 'group2', 'vms' => [{ '_id' => 'vm-3', 'name' => 'db01' }] },
+        { '_id' => 'rg-9', 'name' => 'unrelated', 'vms' => [{ '_id' => 'vm-9', 'name' => 'other' }] }
+    ]
+}.freeze
 
-        err = assert_raises(NetAppShift::OperationError) do
-            bare_helper.check!(failing_result(output))
-        end
+SETUP_ROUTES = {
+    '/api/setup/drplan'          => BLUEPRINTS,
+    '/api/setup/protectionGroup' => GROUPS
+}.freeze
 
-        assert_includes err.message, 'Something broke'
-    end
-
-    def test_falls_back_to_generic_message_without_errors
-        err = assert_raises(NetAppShift::OperationError) do
-            bare_helper.check!(failing_result(log_line('nothing useful')))
-        end
-
-        assert_includes err.message, 'no success message'
-    end
-
+def steps(*statuses)
+    { 'steps' => statuses.each_with_index.map do |s, i|
+        { 'description' => "step #{i}", 'status' => s }
+    end }
 end
 
 class ConstructorTest < Minitest::Test
 
     def test_bare_host_gets_https
-        assert_equal 'https://10.0.0.5', quiet_helper(:server => '10.0.0.5').server
+        helper, = helper_with({}, :server => '10.0.0.5')
+        assert_equal 'https://10.0.0.5', helper.server
     end
 
     def test_trailing_slash_stripped
-        assert_equal 'https://shift.local', quiet_helper(:server => 'https://shift.local/').server
+        helper, = helper_with({}, :server => 'https://shift.local/')
+        assert_equal 'https://shift.local', helper.server
     end
 
     def test_port_rejected
-        err = assert_raises(ArgumentError) { quiet_helper(:server => 'https://10.0.0.5:3700') }
+        err = assert_raises(ArgumentError) { helper_with({}, :server => 'https://10.0.0.5:3700') }
         assert_includes err.message, 'must not include a port'
     end
 
     def test_missing_credentials_rejected
-        assert_raises(ArgumentError) { quiet_helper(:username => '') }
-        assert_raises(ArgumentError) { quiet_helper(:password => '') }
-    end
-
-end
-
-class VmDetailTest < Minitest::Test
-
-    def test_minimal_conversion_fields
-        vm = NetAppShift::Helper.vm_detail(:name => 'web01',
-                                           :resource_group_name => 'rg1',
-                                           :boot_order => 2)
-
-        assert_equal({ 'name' => 'web01', 'boot_order' => 2,
-                       'resource_group_name' => 'rg1' }, vm)
-    end
-
-    def test_requires_name
-        assert_raises(ArgumentError) { NetAppShift::Helper.vm_detail({}) }
-    end
-
-end
-
-class ConvertedDisksTest < Minitest::Test
-
-    def test_single_disk
-        Dir.mktmpdir do |mount|
-            File.write(File.join(mount, 'web01.qcow2'), 'x')
-
-            assert_equal [File.join(mount, 'web01.qcow2')],
-                         bare_helper.converted_disks('web01', mount, 1)
-        end
-    end
-
-    def test_multi_disk_ordering
-        Dir.mktmpdir do |mount|
-            # Shift naming observed on hardware: base, _1, _2
-            ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'].each do |f|
-                File.write(File.join(mount, f), 'x')
-            end
-
-            disks = bare_helper.converted_disks('multi', mount, 3)
-
-            assert_equal ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'],
-                         disks.map {|d| File.basename(d) }
-        end
-    end
-
-    def test_missing_disks_named_in_error
-        Dir.mktmpdir do |mount|
-            File.write(File.join(mount, 'web01.qcow2'), 'x')
-
-            err = assert_raises(NetAppShift::Error) do
-                bare_helper.converted_disks('web01', mount, 2)
-            end
-
-            assert_includes err.message, 'web01_1.qcow2'
-            refute_includes err.message, "web01.qcow2,"
-        end
-    end
-
-    def test_does_not_glob_similar_names
-        Dir.mktmpdir do |mount|
-            # A neighboring VM whose name shares the prefix must not satisfy
-            # the check for the missing disk.
-            File.write(File.join(mount, 'web01-old.qcow2'), 'x')
-
-            assert_raises(NetAppShift::Error) do
-                bare_helper.converted_disks('web01', mount, 1)
-            end
-        end
-    end
-
-    def test_rejects_non_positive_count
-        assert_raises(ArgumentError) { bare_helper.converted_disks('web01', '/mnt', 0) }
-    end
-
-end
-
-class WaitForCompletionTest < Minitest::Test
-
-    def make_result(data)
-        NetAppShift::Result.new(:check_migration_status, :data => data, :duration => 0.1)
-    end
-
-    # Helper whose check_migration_status replays canned results
-    def waiting_helper(results)
-        helper = quiet_helper
-        queue  = results.dup
-        helper.define_singleton_method(:check_migration_status) do |_bp, _exec|
-            queue.shift || raise('check_migration_status called too many times')
-        end
-        helper.define_singleton_method(:sleep_between_polls) { nil }
-        helper
-    end
-
-    def ok_result
-        make_result(:ok => true, :status => 'convert_complete', :complete => true,
-                    :running => false, :jobs_ok => true)
-    end
-
-    def running_result
-        make_result(:ok => false, :status => 'False', :complete => false, :running => true)
-    end
-
-    def error_result
-        make_result(:ok => false, :status => 'convert_error', :complete => false,
-                    :running => false)
-    end
-
-    def test_returns_terminal_ok_result
-        helper = waiting_helper([ok_result])
-
-        result = helper.wait_for_completion('bp', 'exec-1')
-
-        assert result.ok?
-        assert_equal 'convert_complete', result[:status]
-    end
-
-    def test_loops_past_python_polling_ceiling
-        helper = waiting_helper([running_result, running_result, ok_result])
-
-        helper.stub(:sleep, nil) do
-            assert helper.wait_for_completion('bp', 'exec-1').ok?
-        end
-    end
-
-    def test_raises_on_error_status
-        helper = waiting_helper([error_result])
-
-        assert_raises(NetAppShift::OperationError) do
-            helper.wait_for_completion('bp', 'exec-1')
-        end
-    end
-
-    def test_raises_on_complete_with_failed_jobs
-        helper = waiting_helper([make_result(:ok => false, :status => 'convert_complete',
-                                             :complete => true, :running => false,
-                                             :jobs_ok => false)])
-
-        assert_raises(NetAppShift::OperationError) do
-            helper.wait_for_completion('bp', 'exec-1')
-        end
-    end
-
-    def test_overall_timeout
-        helper = waiting_helper([running_result, running_result, running_result])
-
-        helper.stub(:sleep, nil) do
-            err = assert_raises(NetAppShift::OperationError) do
-                # An already-expired deadline: the first still-running result
-                # must trip the overall timeout rather than polling again.
-                helper.wait_for_completion('bp', 'exec-1', :timeout => 1e-9)
-            end
-
-            assert_includes err.message, 'Timed out'
-        end
-    end
-
-    def test_nil_timeout_keeps_waiting
-        helper = waiting_helper([running_result] * 5 + [ok_result])
-
-        helper.stub(:sleep, nil) do
-            assert helper.wait_for_completion('bp', 'exec-1', :timeout => nil).ok?
-        end
+        assert_raises(ArgumentError) { helper_with({}, :username => '') }
+        assert_raises(ArgumentError) { helper_with({}, :password => '') }
     end
 
 end
 
 class BlueprintVmNamesTest < Minitest::Test
 
-    BLUEPRINTS = {
-        'list' => [
-            { '_id' => 'bp-1', 'name' => 'bp_web',
-              'protectionGroups' => [{ '_id' => 'rg-1' }] },
-            { '_id' => 'bp-2', 'name' => 'bp_all',
-              'protectionGroups' => [{ '_id' => 'rg-1' }, { '_id' => 'rg-2' }] }
-        ]
-    }.freeze
-
-    GROUPS = {
-        'list' => [
-            { '_id' => 'rg-1', 'name' => 'group1',
-              'vms' => [{ '_id' => 'vm-1', 'name' => 'web01' },
-                        { '_id' => 'vm-2', 'name' => 'web02' }] },
-            { '_id' => 'rg-2', 'name' => 'group2',
-              'vms' => [{ '_id' => 'vm-3', 'name' => 'db01' }] },
-            { '_id' => 'rg-9', 'name' => 'unrelated',
-              'vms' => [{ '_id' => 'vm-9', 'name' => 'other' }] }
-        ]
-    }.freeze
-
-    # Helper whose api_request replays canned appliance responses
-    def rest_helper
-        helper = quiet_helper
-        calls  = []
-        helper.define_singleton_method(:api_request) do |_method, _port, path, **_kw|
-            calls << path
-            case path
-            when '/api/tenant/session'     then { 'session' => { '_id' => 'sid-1' } }
-            when '/api/tenant/session/end' then {}
-            when '/api/setup/drplan'          then BLUEPRINTS
-            when '/api/setup/protectionGroup' then GROUPS
-            else raise "unexpected path #{path}"
-            end
-        end
-        [helper, calls]
-    end
-
     def test_single_group
-        helper, = rest_helper
-
-        assert_equal %w[web01 web02], helper.blueprint_vm_names('bp_web')
+        helper, = helper_with(SETUP_ROUTES)
+        assert_equal %w[web01 web02], helper.blueprint_vm_names('multidisk')
     end
 
     def test_multiple_groups_in_order
-        helper, = rest_helper
-
-        assert_equal %w[web01 web02 db01], helper.blueprint_vm_names('bp_all')
+        helper, = helper_with(SETUP_ROUTES)
+        assert_equal %w[web01 web02 db01], helper.blueprint_vm_names('waves')
     end
 
     def test_unknown_blueprint_lists_available
-        helper, = rest_helper
+        helper, = helper_with(SETUP_ROUTES)
 
-        err = assert_raises(NetAppShift::OperationError) do
-            helper.blueprint_vm_names('nope')
-        end
+        err = assert_raises(NetAppShift::OperationError) { helper.blueprint_vm_names('nope') }
 
-        assert_includes err.message, 'bp_web'
-        assert_includes err.message, 'bp_all'
+        assert_includes err.message, 'multidisk'
+        assert_includes err.message, 'waves'
     end
 
-    def test_session_always_ended
-        helper, calls = rest_helper
+    def test_session_opened_and_ended
+        helper, fake = helper_with(SETUP_ROUTES)
+        helper.blueprint_vm_names('multidisk')
 
-        helper.blueprint_vm_names('bp_web')
-        assert_includes calls, '/api/tenant/session/end'
+        assert_includes fake.paths, '/api/tenant/session'
+        assert_includes fake.paths, '/api/tenant/session/end'
+    end
 
-        calls.clear
+    def test_session_ended_even_on_failure
+        helper, fake = helper_with(SETUP_ROUTES)
         assert_raises(NetAppShift::OperationError) { helper.blueprint_vm_names('nope') }
-        assert_includes calls, '/api/tenant/session/end'
+
+        assert_includes fake.paths, '/api/tenant/session/end'
+    end
+
+    def test_session_is_reused_not_reopened
+        helper, fake = helper_with(SETUP_ROUTES)
+        helper.blueprint_vm_names('multidisk')
+
+        # one open for the whole call, despite two setup GETs inside it
+        assert_equal 1, fake.paths.count('/api/tenant/session')
+        assert_equal 'sid-1', fake.find('/api/setup/drplan')[:session]
     end
 
 end
 
 class BlueprintExecutionStateTest < Minitest::Test
 
-    BLUEPRINTS = {
-        'list' => [{ '_id' => 'bp-1', 'name' => 'multidisk', 'protectionGroups' => [] }]
-    }.freeze
-
-    # Helper whose api_request replays a canned /api/recovery/drplan/status
-    def state_helper(status_body)
-        helper = quiet_helper
-        ports  = []
-        helper.define_singleton_method(:api_request) do |_method, port, path, **_kw|
-            ports << [port, path]
-            case path
-            when '/api/tenant/session'          then { 'session' => { '_id' => 'sid-1' } }
-            when '/api/tenant/session/end'      then {}
-            when '/api/setup/drplan'            then BLUEPRINTS
-            when '/api/recovery/drplan/status'  then status_body
-            else raise "unexpected path #{path}"
-            end
-        end
-        [helper, ports]
-    end
-
     def entry(recovery_status, exec_id = 'ex-1', bp_id = 'bp-1')
         { 'drPlan'        => { '_id' => bp_id, 'recoveryStatus' => recovery_status },
-          'lastExecution' => { '_id' => exec_id, 'status' => 4 } }
+          'lastExecution' => { '_id' => exec_id } }
+    end
+
+    def state_helper(status_body)
+        helper_with(SETUP_ROUTES.merge('/api/recovery/drplan/status' => status_body))
     end
 
     def test_completed_conversion
-        helper, ports = state_helper([entry('convert_complete')])
-
+        helper, fake = state_helper([entry('convert_complete')])
         state = helper.blueprint_execution_state('multidisk')
 
         assert state[:complete]
         refute state[:running]
         refute state[:failed]
-        assert_equal 'convert_complete', state[:status]
         assert_equal 'ex-1', state[:execution_id]
-
-        # must query the recovery service, not the setup service
-        assert_includes ports, [NetAppShift::Helper::RECOVERY_PORT,
-                                '/api/recovery/drplan/status']
+        assert_equal NetAppShift::Helper::RECOVERY_PORT,
+                     fake.find('/api/recovery/drplan/status')[:port]
     end
 
     def test_running_execution
         helper, = state_helper([entry('convert_inprogress')])
-
         state = helper.blueprint_execution_state('multidisk')
 
         assert state[:running]
         refute state[:complete]
-        assert_equal 'ex-1', state[:execution_id]
     end
 
     def test_failed_execution
         helper, = state_helper([entry('convert_error')])
-
         state = helper.blueprint_execution_state('multidisk')
 
         assert state[:failed]
@@ -528,151 +217,327 @@ class BlueprintExecutionStateTest < Minitest::Test
         refute state[:running]
     end
 
-    def test_never_run_returns_nil
-        # blueprint absent from the status list entirely
+    def test_absent_blueprint_returns_nil
         helper, = state_helper([entry('convert_complete', 'ex-9', 'bp-other')])
-
         assert_nil helper.blueprint_execution_state('multidisk')
     end
 
     def test_empty_status_returns_nil
         helper, = state_helper([entry('')])
-
         assert_nil helper.blueprint_execution_state('multidisk')
     end
 
-    def test_empty_status_list_returns_nil
+    def test_empty_list_returns_nil
         helper, = state_helper([])
-
         assert_nil helper.blueprint_execution_state('multidisk')
     end
 
-    # Some appliances may wrap the collection the way the setup service does
     def test_tolerates_list_envelope
         helper, = state_helper('list' => [entry('convert_complete')])
-
         assert helper.blueprint_execution_state('multidisk')[:complete]
     end
 
     def test_tolerates_junk_entries
         helper, = state_helper(['nonsense', nil, entry('convert_complete')])
-
         assert helper.blueprint_execution_state('multidisk')[:complete]
     end
 
 end
 
-class ScriptPlumbingTest < Minitest::Test
+class ExecutionStatusTest < Minitest::Test
 
-    # Build a fake script dir + interpreter that echoes the payload it was
-    # given and replays a realistic success log to stderr (where Python
-    # logging writes).
-    def with_stub_env
-        Dir.mktmpdir do |dir|
-            script_dir = File.join(dir, 'Python')
-            FileUtils.mkdir_p(script_dir)
+    S = NetAppShift::Helper::STEP_SUCCESS
+    F = NetAppShift::Helper::STEP_FAILED
 
-            NetAppShift::Helper::OPERATIONS.each_value do |name|
-                File.write(File.join(script_dir, "#{name}.py"), "# stub\n")
-                File.write(File.join(script_dir, "#{name}.json"),
-                           %({"executions": [{"execution_name": ""}]}\n))
-                File.chmod(0o644, File.join(script_dir, "#{name}.json"))
+    def status_for(body)
+        helper, = helper_with(%r{/api/recovery/execution/.*/steps} => body)
+        helper.execution_status('ex-1')
+    end
+
+    def test_all_success_is_complete
+        assert_equal :complete, status_for(steps(S, S, S))
+    end
+
+    def test_any_failure_is_failed
+        assert_equal :failed, status_for(steps(S, F, S))
+    end
+
+    def test_mixed_pending_is_running
+        assert_equal :running, status_for(steps(S, 2, S))
+    end
+
+    def test_no_steps_is_unknown
+        assert_equal :unknown, status_for('steps' => [])
+    end
+
+    def test_hits_the_execution_scoped_path
+        helper, fake = helper_with(%r{/api/recovery/execution/.*/steps} => steps(S))
+        helper.execution_status('ex-42')
+
+        assert_includes fake.paths, '/api/recovery/execution/ex-42/steps'
+    end
+
+end
+
+class WaitForCompletionTest < Minitest::Test
+
+    S = NetAppShift::Helper::STEP_SUCCESS
+    F = NetAppShift::Helper::STEP_FAILED
+
+    def waiter(*bodies)
+        helper_with(%r{/api/recovery/execution/.*/steps} => sequence(*bodies))
+    end
+
+    def test_returns_when_all_steps_succeed
+        helper, = waiter(steps(S, S))
+        result = helper.wait_for_completion('bp', 'ex-1')
+
+        assert_equal 'complete', result[:status]
+        assert_equal 2, result[:steps].length
+    end
+
+    def test_polls_while_running
+        helper, fake = waiter(steps(S, 2), steps(S, 2), steps(S, S))
+        assert_equal 'complete', helper.wait_for_completion('bp', 'ex-1')[:status]
+        assert_equal 3, fake.paths.count('/api/recovery/execution/ex-1/steps')
+    end
+
+    def test_raises_naming_the_failed_step
+        helper, = waiter(steps(S, F))
+
+        err = assert_raises(NetAppShift::OperationError) { helper.wait_for_completion('bp', 'ex-1') }
+
+        assert_includes err.message, 'step 1'
+        assert_includes err.message, 'ex-1'
+    end
+
+    def test_overall_timeout
+        helper, = waiter(steps(S, 2))
+
+        err = assert_raises(NetAppShift::OperationError) do
+            helper.wait_for_completion('bp', 'ex-1', :timeout => 1e-9)
+        end
+
+        assert_includes err.message, 'Timed out'
+    end
+
+    def test_nil_timeout_keeps_waiting
+        helper, = waiter(steps(2), steps(2), steps(2), steps(2), steps(S))
+        assert_equal 'complete', helper.wait_for_completion('bp', 'ex-1', :timeout => nil)[:status]
+    end
+
+end
+
+class ComplianceCheckTest < Minitest::Test
+
+    def compliance_helper(*poll_bodies, request: { 'taskId' => 'task-9' })
+        helper_with(
+            SETUP_ROUTES.merge(
+                %r{/checkrequest\?async=true} => request,
+                %r{/checkrequest\?taskId=}    => sequence(*poll_bodies)
+            ),
+            :timeouts => { :compliance_settle => 0 }
+        )
+    end
+
+    def test_requests_then_polls_until_succeeded
+        helper, fake = compliance_helper({ 'status' => 'running' },
+                                         { 'status' => 'succeeded', 'result' => [{ 'a' => 1 }] })
+        result = helper.run_compliance_check('multidisk')
+
+        assert_equal 'task-9', result[:task_id]
+        assert_equal [{ 'a' => 1 }], result[:result]
+        assert_includes fake.paths, '/api/setup/compliance/drplan/bp-1/checkrequest?async=true'
+        # the task id goes in both the path and the query on the poll
+        assert_includes fake.paths,
+                        '/api/setup/compliance/drplan/task-9/checkrequest?taskId=task-9'
+    end
+
+    def test_uses_the_setup_port
+        helper, fake = compliance_helper({ 'status' => 'succeeded' })
+        helper.run_compliance_check('multidisk')
+
+        assert_equal NetAppShift::Helper::SETUP_PORT, fake.find('checkrequest')[:port]
+    end
+
+    def test_missing_task_id_raises
+        helper, = compliance_helper({ 'status' => 'succeeded' }, :request => {})
+
+        err = assert_raises(NetAppShift::OperationError) { helper.run_compliance_check('multidisk') }
+        assert_includes err.message, 'no task id'
+    end
+
+    def test_failed_status_raises
+        helper, = compliance_helper({ 'status' => 'failed', 'result' => ['bad'] })
+
+        err = assert_raises(NetAppShift::OperationError) { helper.run_compliance_check('multidisk') }
+        assert_includes err.message, 'failed'
+    end
+
+    def test_gives_up_after_the_poll_limit
+        helper, = helper_with(
+            SETUP_ROUTES.merge(%r{/checkrequest\?async=true} => { 'taskId' => 't' },
+                               %r{/checkrequest\?taskId=}    => { 'status' => 'running' }),
+            :timeouts => { :compliance_settle => 0, :compliance_poll_limit => 3,
+                           :compliance_poll_interval => 0 }
+        )
+
+        err = assert_raises(NetAppShift::OperationError) { helper.run_compliance_check('multidisk') }
+        assert_includes err.message, 'did not finish'
+    end
+
+end
+
+class TriggerConversionTest < Minitest::Test
+
+    def trigger_helper(response)
+        helper_with(SETUP_ROUTES.merge(%r{/execution\z} => response))
+    end
+
+    def test_returns_execution_id_from_the_convert_path
+        helper, fake = trigger_helper('_id' => 'ex-77')
+
+        assert_equal 'ex-77', helper.trigger_conversion('multidisk')
+        # capital P in drPlan here, unlike /api/recovery/drplan/status
+        assert_includes fake.paths, '/api/recovery/drPlan/bp-1/convert/execution'
+        assert_equal NetAppShift::Helper::RECOVERY_PORT, fake.find('/execution')[:port]
+    end
+
+    def test_sends_the_empty_service_accounts_payload
+        helper, fake = trigger_helper('_id' => 'ex-77')
+        helper.trigger_conversion('multidisk')
+
+        assert_equal({ 'common' => { 'loginId' => nil, 'password' => nil }, 'vms' => [] },
+                     fake.find('/execution')[:body]['serviceAccounts'])
+    end
+
+    def test_migrate_mode_uses_the_migrate_path
+        helper, fake = trigger_helper('_id' => 'ex-77')
+        helper.trigger_conversion('multidisk', NetAppShift::Helper::MIGRATION)
+
+        assert_includes fake.paths, '/api/recovery/drPlan/bp-1/migrate/execution'
+    end
+
+    def test_finds_a_nested_execution_id
+        helper, = trigger_helper('execution' => { '_id' => 'ex-nested' })
+        assert_equal 'ex-nested', helper.trigger_conversion('multidisk')
+    end
+
+    def test_missing_execution_id_raises
+        helper, = trigger_helper({})
+
+        err = assert_raises(NetAppShift::OperationError) { helper.trigger_conversion('multidisk') }
+        assert_includes err.message, 'no execution id'
+    end
+
+end
+
+# Fake Net::HTTPResponse for the error-translation layer
+FakeResponse = Struct.new(:code, :body) do
+    def is_a?(klass)
+        klass == Net::HTTPSuccess ? false : super
+    end
+end
+
+class ApiErrorTranslationTest < Minitest::Test
+
+    # Verbatim body from a real appliance, trimmed. Note their "succesful"
+    # typo -- never match on it.
+    ERSCSTEX009_BODY = {
+        'level'   => 'error',
+        'message' => 'ERSCSTEX009: The -convert execution is succesful for Blueprint ' \
+                     '- 588314a3. No further execution is allowed.',
+        'errors'  => [{
+            'code'    => 'ERSCSTEX009',
+            'message' => 'ERSCSTEX009: The -convert execution is succesful for ' \
+                         'Blueprint - 588314a3. No further execution is allowed.',
+            'level'   => 'error'
+        }]
+    }.freeze
+
+    def raise_for(code, body)
+        helper = NetAppShift::Helper.allocate
+        helper.send(:raise_api_error, FakeResponse.new(code, body), '/some/path')
+    end
+
+    def test_already_executed_is_its_own_error
+        err = assert_raises(NetAppShift::AlreadyExecuted) do
+            raise_for('500', JSON.generate(ERSCSTEX009_BODY))
+        end
+
+        assert_equal 'ERSCSTEX009', err.code
+        assert_equal 500, err.http_status
+        assert_includes err.message, 'No further execution is allowed'
+    end
+
+    def test_already_executed_detected_without_a_code
+        body = { 'message' => 'No further execution is allowed.' }
+
+        assert_raises(NetAppShift::AlreadyExecuted) { raise_for('500', JSON.generate(body)) }
+    end
+
+    def test_other_errors_surface_the_appliance_message
+        body = { 'errors' => [{ 'code' => 'ERAUTH001', 'message' => 'Session expired' }] }
+
+        err = assert_raises(NetAppShift::OperationError) { raise_for('401', JSON.generate(body)) }
+
+        refute_kind_of NetAppShift::AlreadyExecuted, err
+        assert_includes err.message, 'Session expired'
+        assert_includes err.message, '401'
+        assert_equal 'ERAUTH001', err.code
+    end
+
+    def test_non_json_body_still_raises_usefully
+        err = assert_raises(NetAppShift::OperationError) { raise_for('502', '<html>bad gateway</html>') }
+
+        assert_includes err.message, '502'
+        assert_includes err.message, 'bad gateway'
+    end
+
+end
+
+class ConvertedDisksTest < Minitest::Test
+
+    def bare
+        NetAppShift::Helper.allocate
+    end
+
+    def test_single_disk
+        Dir.mktmpdir do |mount|
+            File.write(File.join(mount, 'web01.qcow2'), 'x')
+            assert_equal [File.join(mount, 'web01.qcow2')], bare.converted_disks('web01', mount, 1)
+        end
+    end
+
+    def test_multi_disk_ordering
+        Dir.mktmpdir do |mount|
+            ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'].each do |f|
+                File.write(File.join(mount, f), 'x')
             end
 
-            stub = File.join(dir, 'fakepython')
-            File.write(stub, <<~SH)
-              #!/bin/bash
-              if [ "$1" = "-c" ]; then exit 0; fi
-              base="${1%.py}"
-              cp "$base.json" "#{dir}/seen-$base.json"
-              case "$base" in
-                trigger_migration)
-                  echo "#{log_line('Migration triggered for blueprint bp with execution id: ex-42')}" >&2 ;;
-                check_migration_status)
-                  echo "#{log_line('Status of Blueprint is convert_complete for blueprint bp-abc')}" >&2
-                  echo "#{log_line('Job steps successfully completed for execution id ex-42')}" >&2 ;;
-              esac
-              exit 0
-            SH
-            FileUtils.chmod(0o755, stub)
-
-            helper = quiet_helper(:script_dir => script_dir, :python => stub)
-
-            yield helper, script_dir, dir
+            assert_equal ['multi.qcow2', 'multi_1.qcow2', 'multi_2.qcow2'],
+                         bare.converted_disks('multi', mount, 3).map {|d| File.basename(d) }
         end
     end
 
-    def test_trigger_runs_and_parses
-        with_stub_env do |helper, _script_dir, dir|
-            result = helper.trigger_migration('bp')
+    def test_missing_disks_named_in_error
+        Dir.mktmpdir do |mount|
+            File.write(File.join(mount, 'web01.qcow2'), 'x')
 
-            assert result.ok?
-            assert_equal 'ex-42', result[:execution_id]
-            assert_equal 0, result.exit_code
-
-            seen = JSON.parse(File.read(File.join(dir, 'seen-trigger_migration.json')))
-            exec = seen['executions'].first
-
-            assert_equal 'admin', exec['shift_username']
-            assert_equal 's3cr3t', exec['shift_password']
-            assert_equal 'https://shift.local', exec['shift_server_ip']
-            assert_equal 'bp', exec['blueprint_name']
-            assert_equal 'clone_based_conversion', exec['migration_mode']
+            err = assert_raises(NetAppShift::Error) { bare.converted_disks('web01', mount, 2) }
+            assert_includes err.message, 'web01_1.qcow2'
         end
     end
 
-    def test_payload_file_restored_with_mode
-        with_stub_env do |helper, script_dir, _dir|
-            original = File.join(script_dir, 'trigger_migration.json')
-
-            helper.trigger_migration('bp')
-
-            assert_equal({ 'execution_name' => '' },
-                         JSON.parse(File.read(original))['executions'].first)
-            assert_equal '644', format('%o', File.stat(original).mode & 0o777)
+    def test_does_not_glob_similar_names
+        Dir.mktmpdir do |mount|
+            File.write(File.join(mount, 'web01-old.qcow2'), 'x')
+            assert_raises(NetAppShift::Error) { bare.converted_disks('web01', mount, 1) }
         end
     end
 
-    def test_check_migration_status_passes_execution_id
-        with_stub_env do |helper, _script_dir, dir|
-            result = helper.check_migration_status('bp', 'ex-42')
-
-            assert result.ok?
-
-            seen = JSON.parse(File.read(File.join(dir, 'seen-check_migration_status.json')))
-
-            assert_equal 'ex-42', seen['executions'].first['execution_id']
-        end
-    end
-
-    def test_check_bang_raises_with_last_error
-        with_stub_env do |helper, _script_dir, _dir|
-            # get_site stub logs nothing -> no success message
-            err = assert_raises(NetAppShift::OperationError) do
-                helper.check!(helper.get_site)
-            end
-
-            assert_includes err.message, 'get_site'
-        end
-    end
-
-    def test_missing_script_dir_raises_dependency_error
-        helper = quiet_helper(:script_dir => '/nonexistent/shift')
-
-        err = assert_raises(NetAppShift::DependencyError) { helper.get_site }
-        assert_includes err.message, 'submodule'
-    end
-
-    def test_dry_run_skips_python_and_redacts
-        helper = quiet_helper(:script_dir => '/nonexistent', :dry_run => true)
-
-        assert helper.get_site.ok?
-        assert helper.get_site[:dry_run]
-
-        redacted = helper.send(:redact, helper.send(:base_execution))
-
-        assert_equal '[redacted]', redacted['shift_password']
-        assert_equal 'admin', redacted['shift_username']
+    def test_rejects_non_positive_count
+        assert_raises(ArgumentError) { bare.converted_disks('web01', '/mnt', 0) }
     end
 
 end

--- a/tests/netapp_shift_mode_test.rb
+++ b/tests/netapp_shift_mode_test.rb
@@ -175,7 +175,8 @@ class NetAppShiftModeTest < Minitest::Test
 
 end
 
-# Fake NetAppShift::Helper for orchestration tests
+# Fake NetAppShift::Helper for the orchestration tests. Mirrors the real
+# client's contract: reads return data, actions raise on failure.
 class FakeShift
 
     attr_reader :calls
@@ -185,35 +186,49 @@ class FakeShift
         @calls     = []
     end
 
-    def blueprint_execution_state(bp)
-        @calls << [:state, bp]
-        @responses.fetch(:state, nil)
+    def verbs
+        @calls.map(&:first)
     end
 
-    def run_compliance_check(bp)
-        @calls << [:compliance, bp]
-        @responses.fetch(:compliance)
+    def blueprint_execution_state(blueprint)
+        @calls << [:state, blueprint]
+        replay(:state, nil)
     end
 
-    def trigger_migration(bp)
-        @calls << [:trigger, bp]
-        @responses.fetch(:trigger)
+    def blueprint_vm_names(blueprint)
+        @calls << [:vm_names, blueprint]
+        replay(:vm_names)
     end
 
-    def wait_for_completion(bp, exec_id, timeout: nil)
-        @calls << [:wait, bp, exec_id, timeout]
-        @responses.fetch(:wait)
+    def run_compliance_check(blueprint)
+        @calls << [:compliance, blueprint]
+        replay(:compliance, {})
     end
 
-    def blueprint_vm_names(bp)
-        @calls << [:vm_names, bp]
-        @responses.fetch(:vm_names)
+    def trigger_conversion(blueprint)
+        @calls << [:trigger, blueprint]
+        replay(:trigger)
     end
 
-    def check!(result)
-        raise NetAppShift::OperationError, "failed: #{result.operation}" unless result.ok?
+    def wait_for_completion(blueprint, execution_id, timeout: nil)
+        @calls << [:wait, blueprint, execution_id, timeout]
+        replay(:wait, { :status => 'complete' })
+    end
 
-        result
+    private
+
+    # A stored exception is raised; anything else is returned.
+    def replay(key, default = :__required__)
+        value = @responses.fetch(key) do
+            raise "test: FakeShift has no :#{key} response" if default == :__required__
+
+            default
+        end
+
+        raise value if value.is_a?(Class) && value <= StandardError
+        raise value if value.is_a?(StandardError)
+
+        value
     end
 
 end
@@ -221,67 +236,108 @@ end
 class ShiftExecuteBlueprintTest < Minitest::Test
 
     OPTIONS = {
-        :shift            => 'https://shift.local',
-        :shift_user       => 'admin',
-        :shift_pass       => 'p',
-        :shift_blueprint  => 'bp1',
-        :shift_wait_timeout => 3600
+        :shift               => 'https://shift.local',
+        :shift_user          => 'admin',
+        :shift_pass          => 'p',
+        :shift_blueprint     => 'bp1',
+        :shift_mount         => '/mnt/shift',
+        :shift_wait_timeout  => 3600
     }.freeze
-
-    def result(op, data)
-        NetAppShift::Result.new(op, :data => data, :duration => 0.1)
-    end
 
     def orchestration_helper(fake)
         h = OneSwapHelper.allocate
         h.instance_variable_set(:@logger, Logger.new(File::NULL))
-        h.instance_variable_set(:@verbose, true) # short-circuit apply_verbosity
+        h.instance_variable_set(:@verbose, true) # short-circuits apply_verbosity
         h.define_singleton_method(:check_one_connectivity) { nil }
         h.define_singleton_method(:local_path_image_allocation_preflight!) { nil }
         h.define_singleton_method(:new_netapp_shift) {|_opts| fake }
         h
     end
 
-    def test_happy_path_passes_blueprint_execution_id_and_timeout
-        fake = FakeShift.new(
-            :compliance => result(:run_compliance_check, :ok => true),
-            :trigger    => result(:trigger_migration, :ok => true, :execution_id => 'ex-9'),
-            :wait       => result(:check_migration_status,
-                                  :ok => true, :status => 'convert_complete')
-        )
-        h = orchestration_helper(fake)
+    def run_it(fake)
+        capture_io { orchestration_helper(fake).shift_execute_blueprint(OPTIONS.dup) }
+    end
 
-        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+    def test_happy_path_passes_blueprint_execution_id_and_timeout
+        fake = FakeShift.new(:state => nil, :trigger => 'ex-9')
+
+        run_it(fake)
 
         assert_includes fake.calls, [:compliance, 'bp1']
         assert_includes fake.calls, [:trigger, 'bp1']
         assert_includes fake.calls, [:wait, 'bp1', 'ex-9', 3600]
     end
 
-    def test_missing_execution_id_raises
-        fake = FakeShift.new(
-            :compliance => result(:run_compliance_check, :ok => true),
-            :trigger    => result(:trigger_migration, :ok => true) # no execution_id
-        )
-        h = orchestration_helper(fake)
+    # The reported bug: a blueprint that already converted must not be
+    # triggered again, it must fall through to import.
+    def test_already_converted_state_skips_compliance_and_trigger
+        fake = FakeShift.new(:state => { :status => 'convert_complete', :complete => true,
+                                         :running => false, :failed => false,
+                                         :execution_id => 'ex-1' })
 
-        err = assert_raises(RuntimeError) do
-            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-        end
+        out, = run_it(fake)
 
-        assert_includes err.message, 'no execution id'
+        assert_equal [[:state, 'bp1']], fake.calls
+        assert_includes out, 'already been converted'
     end
 
-    def test_operation_error_becomes_plain_runtime_error
-        fake = FakeShift.new(:compliance => result(:run_compliance_check, :ok => false))
-        h = orchestration_helper(fake)
+    # And when the status endpoint does not report it, Shift's own rejection
+    # of the second execution must be treated the same way.
+    def test_already_executed_on_trigger_is_not_an_error
+        fake = FakeShift.new(:state => nil, :trigger => NetAppShift::AlreadyExecuted)
 
-        err = assert_raises(RuntimeError) do
-            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-        end
+        out, = run_it(fake)
 
-        refute_kind_of NetAppShift::OperationError, err
-        assert_includes err.message, 'run_compliance_check'
+        assert_includes out, 'already been converted'
+        refute_includes fake.verbs, :wait
+    end
+
+    def test_running_blueprint_attaches_to_existing_execution
+        fake = FakeShift.new(:state => { :status => 'convert_inprogress', :complete => false,
+                                         :running => true, :failed => false,
+                                         :execution_id => 'ex-7' })
+
+        run_it(fake)
+
+        assert_includes fake.calls, [:wait, 'bp1', 'ex-7', 3600]
+        refute_includes fake.verbs, :trigger
+        refute_includes fake.verbs, :compliance
+    end
+
+    def test_failed_blueprint_raises_without_triggering
+        fake = FakeShift.new(:state => { :status => 'convert_error', :complete => false,
+                                         :running => false, :failed => true,
+                                         :execution_id => 'ex-3' })
+
+        err = assert_raises(RuntimeError) { run_it(fake) }
+
+        assert_includes err.message, 'last execution failed'
+        refute_includes fake.verbs, :trigger
+    end
+
+    def test_compliance_failure_becomes_a_plain_error
+        fake = FakeShift.new(
+            :state      => nil,
+            :compliance => NetAppShift::OperationError.new('compliance check failed: nope')
+        )
+
+        err = assert_raises(RuntimeError) { run_it(fake) }
+
+        refute_kind_of NetAppShift::Error, err
+        assert_includes err.message, 'compliance check failed'
+        refute_includes fake.verbs, :trigger
+    end
+
+    def test_trigger_failure_propagates
+        fake = FakeShift.new(
+            :state   => nil,
+            :trigger => NetAppShift::OperationError.new('returned no execution id')
+        )
+
+        err = assert_raises(RuntimeError) { run_it(fake) }
+
+        assert_includes err.message, 'no execution id'
+        refute_includes fake.verbs, :wait
     end
 
     def test_blueprint_vm_names_delegates
@@ -289,96 +345,6 @@ class ShiftExecuteBlueprintTest < Minitest::Test
         h = orchestration_helper(fake)
 
         assert_equal %w[web01 db01], h.shift_blueprint_vm_names(OPTIONS.dup)
-    end
-
-    # The reported bug: a blueprint that already converted must not be
-    # triggered again (Shift rejects it), it must fall through to import.
-    def test_already_converted_blueprint_skips_compliance_and_trigger
-        fake = FakeShift.new(:state => { :status => 'convert_complete', :complete => true,
-                                         :running => false, :failed => false,
-                                         :execution_id => 'ex-1' })
-        h = orchestration_helper(fake)
-
-        out, = capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-
-        assert_equal [[:state, 'bp1']], fake.calls
-        assert_includes out, 'already been converted'
-    end
-
-    def test_running_blueprint_attaches_to_existing_execution
-        fake = FakeShift.new(
-            :state => { :status => 'convert_inprogress', :complete => false,
-                        :running => true, :failed => false, :execution_id => 'ex-7' },
-            :wait  => result(:check_migration_status, :ok => true,
-                             :status => 'convert_complete')
-        )
-        h = orchestration_helper(fake)
-
-        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-
-        assert_includes fake.calls, [:wait, 'bp1', 'ex-7', 3600]
-        refute_includes fake.calls.map(&:first), :trigger
-        refute_includes fake.calls.map(&:first), :compliance
-    end
-
-    def test_failed_blueprint_raises_without_triggering
-        fake = FakeShift.new(:state => { :status => 'convert_error', :complete => false,
-                                         :running => false, :failed => true,
-                                         :execution_id => 'ex-3' })
-        h = orchestration_helper(fake)
-
-        err = assert_raises(RuntimeError) do
-            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-        end
-
-        assert_includes err.message, 'last execution failed'
-        refute_includes fake.calls.map(&:first), :trigger
-    end
-
-    # Safety net for when the status pre-check does not see the blueprint:
-    # Shift's own ERSCSTEX009 rejection must be treated as "already done",
-    # not as a failure.
-    def test_erscstex009_on_trigger_is_not_an_error
-        fake = FakeShift.new(
-            :state      => nil,
-            :compliance => result(:run_compliance_check, :ok => true),
-            :trigger    => result(:trigger_migration, :ok => false, :already_executed => true)
-        )
-        h = orchestration_helper(fake)
-
-        out, = capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-
-        assert_includes out, 'already been converted'
-        refute_includes fake.calls.map(&:first), :wait
-    end
-
-    def test_other_trigger_failures_still_raise
-        fake = FakeShift.new(
-            :state      => nil,
-            :compliance => result(:run_compliance_check, :ok => true),
-            :trigger    => result(:trigger_migration, :ok => false, :already_executed => false)
-        )
-        h = orchestration_helper(fake)
-
-        assert_raises(RuntimeError) do
-            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-        end
-    end
-
-    def test_never_run_blueprint_still_triggers
-        fake = FakeShift.new(
-            :state      => nil,
-            :compliance => result(:run_compliance_check, :ok => true),
-            :trigger    => result(:trigger_migration, :ok => true, :execution_id => 'ex-9'),
-            :wait       => result(:check_migration_status, :ok => true,
-                                  :status => 'convert_complete')
-        )
-        h = orchestration_helper(fake)
-
-        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
-
-        assert_includes fake.calls, [:compliance, 'bp1']
-        assert_includes fake.calls, [:trigger, 'bp1']
     end
 
 end

--- a/tests/netapp_shift_mode_test.rb
+++ b/tests/netapp_shift_mode_test.rb
@@ -185,6 +185,11 @@ class FakeShift
         @calls     = []
     end
 
+    def blueprint_execution_state(bp)
+        @calls << [:state, bp]
+        @responses.fetch(:state, nil)
+    end
+
     def run_compliance_check(bp)
         @calls << [:compliance, bp]
         @responses.fetch(:compliance)
@@ -284,6 +289,96 @@ class ShiftExecuteBlueprintTest < Minitest::Test
         h = orchestration_helper(fake)
 
         assert_equal %w[web01 db01], h.shift_blueprint_vm_names(OPTIONS.dup)
+    end
+
+    # The reported bug: a blueprint that already converted must not be
+    # triggered again (Shift rejects it), it must fall through to import.
+    def test_already_converted_blueprint_skips_compliance_and_trigger
+        fake = FakeShift.new(:state => { :status => 'convert_complete', :complete => true,
+                                         :running => false, :failed => false,
+                                         :execution_id => 'ex-1' })
+        h = orchestration_helper(fake)
+
+        out, = capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+
+        assert_equal [[:state, 'bp1']], fake.calls
+        assert_includes out, 'already been converted'
+    end
+
+    def test_running_blueprint_attaches_to_existing_execution
+        fake = FakeShift.new(
+            :state => { :status => 'convert_inprogress', :complete => false,
+                        :running => true, :failed => false, :execution_id => 'ex-7' },
+            :wait  => result(:check_migration_status, :ok => true,
+                             :status => 'convert_complete')
+        )
+        h = orchestration_helper(fake)
+
+        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+
+        assert_includes fake.calls, [:wait, 'bp1', 'ex-7', 3600]
+        refute_includes fake.calls.map(&:first), :trigger
+        refute_includes fake.calls.map(&:first), :compliance
+    end
+
+    def test_failed_blueprint_raises_without_triggering
+        fake = FakeShift.new(:state => { :status => 'convert_error', :complete => false,
+                                         :running => false, :failed => true,
+                                         :execution_id => 'ex-3' })
+        h = orchestration_helper(fake)
+
+        err = assert_raises(RuntimeError) do
+            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+        end
+
+        assert_includes err.message, 'last execution failed'
+        refute_includes fake.calls.map(&:first), :trigger
+    end
+
+    # Safety net for when the status pre-check does not see the blueprint:
+    # Shift's own ERSCSTEX009 rejection must be treated as "already done",
+    # not as a failure.
+    def test_erscstex009_on_trigger_is_not_an_error
+        fake = FakeShift.new(
+            :state      => nil,
+            :compliance => result(:run_compliance_check, :ok => true),
+            :trigger    => result(:trigger_migration, :ok => false, :already_executed => true)
+        )
+        h = orchestration_helper(fake)
+
+        out, = capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+
+        assert_includes out, 'already been converted'
+        refute_includes fake.calls.map(&:first), :wait
+    end
+
+    def test_other_trigger_failures_still_raise
+        fake = FakeShift.new(
+            :state      => nil,
+            :compliance => result(:run_compliance_check, :ok => true),
+            :trigger    => result(:trigger_migration, :ok => false, :already_executed => false)
+        )
+        h = orchestration_helper(fake)
+
+        assert_raises(RuntimeError) do
+            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+        end
+    end
+
+    def test_never_run_blueprint_still_triggers
+        fake = FakeShift.new(
+            :state      => nil,
+            :compliance => result(:run_compliance_check, :ok => true),
+            :trigger    => result(:trigger_migration, :ok => true, :execution_id => 'ex-9'),
+            :wait       => result(:check_migration_status, :ok => true,
+                                  :status => 'convert_complete')
+        )
+        h = orchestration_helper(fake)
+
+        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+
+        assert_includes fake.calls, [:compliance, 'bp1']
+        assert_includes fake.calls, [:trigger, 'bp1']
     end
 
 end

--- a/tests/netapp_shift_mode_test.rb
+++ b/tests/netapp_shift_mode_test.rb
@@ -62,7 +62,7 @@ class NetAppShiftModeTest < Minitest::Test
             [{ :id => 1, :os => false }]
         end
         h.instance_variable_set(:@props,
-                                'config' => { :hardware => { :memoryMB => 2048 } })
+                                'config' => { :hardware => { :memoryMB => 2048, :numCPU => 4 } })
 
         [h, commands, proc { imported }]
     end
@@ -128,6 +128,32 @@ class NetAppShiftModeTest < Minitest::Test
         end
     end
 
+    # virt-v2v reads /domain/memory/text() as an integer, so a pretty-printed
+    # document ("\n    4096\n  ") makes it bail before it looks at the disks.
+    def test_domain_xml_text_nodes_carry_no_whitespace
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                ['web01.qcow2', 'web01_1.qcow2'].each {|f| File.write(File.join(mount, f), 'x') }
+
+                h, = conversion_helper(mount, work_dir, 2)
+                h.send(:run_shift_conversion)
+
+                doc = REXML::Document.new(
+                    File.read(File.join(work_dir, 'web01-shift-domain.xml'))
+                )
+
+                ['/domain/name', '/domain/memory', '/domain/vcpu', '/domain/os/type'].each do |xpath|
+                    text = doc.elements[xpath].text
+                    refute_nil text, "#{xpath} has no text"
+                    assert_equal text.strip, text, "#{xpath} text is padded: #{text.inspect}"
+                end
+
+                assert_equal '2048', doc.elements['/domain/memory'].text
+                assert_match(/\A\d+\z/, doc.elements['/domain/vcpu'].text)
+            end
+        end
+    end
+
     def test_failed_morph_raises_and_skips_import
         Dir.mktmpdir do |mount|
             Dir.mktmpdir do |work_dir|
@@ -142,6 +168,88 @@ class NetAppShiftModeTest < Minitest::Test
 
                 assert_includes err.message, 'virt-v2v-in-place failed'
                 assert_nil imported.call
+            end
+        end
+    end
+
+    # virt-v2v's real error arrives as --machine-readable JSON on stdout. The
+    # terminal usually shows only teardown noise, so the JSON has to be the
+    # thing that reaches the operator.
+    def test_failure_surfaces_the_machine_readable_error
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+                h, = conversion_helper(mount, work_dir, 1)
+                h.define_singleton_method(:run_cmd_report) do |_cmd, _out = false, **_kw|
+                    out = [
+                        '{"type":"message","message":"Opening the source"}',
+                        '{"type":"error","message":"inspection could not detect the source guest"}',
+                        'fsync: Input/output error'
+                    ].join("\n")
+                    [out, FakeStatus.new(false)]
+                end
+
+                err = assert_raises(RuntimeError) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'inspection could not detect the source guest'
+            end
+        end
+    end
+
+    # virt-v2v refuses guests it does not recognise (Alpine, other minimal
+    # distributions). Many of those boot on KVM unmodified, so the error has
+    # to point at the flag rather than just failing.
+    def test_unsupported_guest_error_names_the_flag
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+                h, = conversion_helper(mount, work_dir, 1)
+                h.define_singleton_method(:run_cmd_report) do |_cmd, _out = false, **_kw|
+                    ['{"type":"error","message":"virt-v2v is unable to convert this ' \
+                     'guest type (linux/alpinelinux)"}', FakeStatus.new(false)]
+                end
+
+                err = assert_raises(RuntimeError) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'linux/alpinelinux'
+                assert_includes err.message, '--shift-skip-morph'
+            end
+        end
+    end
+
+    def test_skip_morph_imports_without_running_virt_v2v
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                disks = ['web01.qcow2', 'web01_1.qcow2'].map {|f| File.join(mount, f) }
+                disks.each {|d| File.write(d, 'x') }
+
+                h, commands, imported = conversion_helper(mount, work_dir, 2,
+                                                          :shift_skip_morph => true)
+                capture_io { h.send(:run_shift_conversion) }
+
+                assert_empty commands
+                assert_equal disks, imported.call
+                # no domain XML needed when the morph is skipped
+                assert_empty Dir.children(work_dir)
+            end
+        end
+    end
+
+    def test_failure_without_json_falls_back_to_the_tail
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+                h, = conversion_helper(mount, work_dir, 1)
+                h.define_singleton_method(:run_cmd_report) do |_cmd, _out = false, **_kw|
+                    ['something broke', FakeStatus.new(false)]
+                end
+
+                err = assert_raises(RuntimeError) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'something broke'
             end
         end
     end
@@ -205,8 +313,8 @@ class FakeShift
         replay(:compliance, {})
     end
 
-    def trigger_conversion(blueprint)
-        @calls << [:trigger, blueprint]
+    def trigger_conversion(blueprint, ignore_powered_on: false)
+        @calls << [:trigger, blueprint, ignore_powered_on]
         replay(:trigger)
     end
 
@@ -264,7 +372,7 @@ class ShiftExecuteBlueprintTest < Minitest::Test
         run_it(fake)
 
         assert_includes fake.calls, [:compliance, 'bp1']
-        assert_includes fake.calls, [:trigger, 'bp1']
+        assert_includes fake.calls, [:trigger, 'bp1', false]
         assert_includes fake.calls, [:wait, 'bp1', 'ex-9', 3600]
     end
 
@@ -345,6 +453,197 @@ class ShiftExecuteBlueprintTest < Minitest::Test
         h = orchestration_helper(fake)
 
         assert_equal %w[web01 db01], h.shift_blueprint_vm_names(OPTIONS.dup)
+    end
+
+    def test_powered_on_vms_error_names_the_flag
+        fake = FakeShift.new(
+            :state   => nil,
+            :trigger => NetAppShift::PoweredOnVms.new(
+                "ERSCSTEX022: Cannot execute the 'convert' action - as some VMs are " \
+                'still powered on.',
+                :vm_names => %w[web01 db01]
+            )
+        )
+
+        err = assert_raises(RuntimeError) { run_it(fake) }
+
+        assert_includes err.message, 'still powered on'
+        assert_includes err.message, 'web01, db01'
+        assert_includes err.message, '--shift-ignore-running-vms'
+        refute_includes fake.verbs, :wait
+    end
+
+    def test_ignore_running_vms_is_passed_through
+        fake = FakeShift.new(:state => nil, :trigger => 'ex-9')
+
+        capture_io do
+            orchestration_helper(fake)
+                .shift_execute_blueprint(OPTIONS.merge(:shift_ignore_running_vms => true))
+        end
+
+        assert_includes fake.calls, [:trigger, 'bp1', true]
+    end
+
+    def test_skip_compliance_still_triggers
+        fake = FakeShift.new(:state => nil, :trigger => 'ex-9')
+
+        out, = capture_io do
+            orchestration_helper(fake)
+                .shift_execute_blueprint(OPTIONS.merge(:shift_skip_compliance => true))
+        end
+
+        refute_includes fake.verbs, :compliance
+        assert_includes fake.verbs, :trigger
+        assert_includes fake.calls, [:wait, 'bp1', 'ex-9', 3600]
+        assert_includes out, 'Skipping Shift compliance check'
+    end
+
+end
+
+# Captures whatever rows a lister hands to the table renderer, standing in for
+# CLIHelper::ShowTable (which needs OpenNebula's CLI libs).
+class FakeTable
+
+    attr_reader :rows, :options
+
+    def show(rows, options)
+        @rows    = rows
+        @options = options
+    end
+
+end
+
+class ShiftListingTest < Minitest::Test
+
+    VMS = [
+        { :name => 'web01', :id => 'vm-1', :resource_group => 'group1' },
+        { :name => 'db01',  :id => 'vm-2', :resource_group => 'group2' }
+    ].freeze
+
+    SUMMARIES = [
+        { :name => 'multidisk', :id => 'bp-1',
+          :resource_groups => ['group1'], :vms => %w[web01 web02] },
+        { :name => 'waves', :id => 'bp-2',
+          :resource_groups => %w[group1 group2], :vms => %w[web01 web02 db01] }
+    ].freeze
+
+    OPTIONS = {
+        :shift           => 'https://shift.local',
+        :shift_user      => 'admin',
+        :shift_pass      => 'p',
+        :shift_blueprint => 'waves'
+    }.freeze
+
+    # Fake client exposing only the two read methods the listers use
+    class ListShift
+
+        def initialize(vms: VMS, summaries: SUMMARIES)
+            @vms = vms
+            @summaries = summaries
+        end
+
+        def blueprint_vms(_bp)
+            raise @vms if @vms.is_a?(StandardError)
+
+            @vms
+        end
+
+        def blueprint_summaries
+            @summaries
+        end
+
+    end
+
+    def lister(shift = ListShift.new)
+        table = FakeTable.new
+        h = OneSwapHelper.allocate
+        h.instance_variable_set(:@logger, Logger.new(File::NULL))
+        h.instance_variable_set(:@verbose, true)
+        h.define_singleton_method(:format_list) { table }
+        h.define_singleton_method(:new_netapp_shift) {|_opts| shift }
+        h.define_singleton_method(:list_vms) {|_opts| :went_to_vcenter }
+        [h, table]
+    end
+
+    def test_list_vms_with_shift_lists_blueprint_vms
+        h, table = lister
+        h.list(OPTIONS.merge(:object => 'vms'))
+
+        assert_equal %w[web01 db01], table.rows.map {|r| r[:name] }
+        assert_equal %w[group1 group2], table.rows.map {|r| r[:resource_group] }
+    end
+
+    def test_list_vms_without_shift_still_uses_vcenter
+        h, table = lister
+        assert_equal :went_to_vcenter, h.list(:object => 'vms')
+        assert_nil table.rows
+    end
+
+    def test_datacenters_are_never_diverted_to_shift
+        h, = lister
+        h.define_singleton_method(:list_datacenters) {|_opts| :went_to_vcenter }
+
+        assert_equal :went_to_vcenter, h.list(OPTIONS.merge(:object => 'datacenters'))
+    end
+
+    def test_list_vms_sets_the_shift_column_set
+        h, = lister
+        h.list(OPTIONS.merge(:object => 'vms'))
+
+        assert_equal OneSwapHelper::VOBJECT::SHIFT_VM, h.instance_variable_get(:@vobject)
+    end
+
+    def test_name_filter_applies_to_blueprint_vms
+        h, table = lister
+        h.list(OPTIONS.merge(:object => 'vms', :name => 'web'))
+
+        assert_equal %w[web01], table.rows.map {|r| r[:name] }
+    end
+
+    def test_list_blueprints_summarises_each
+        h, table = lister
+        h.list(OPTIONS.merge(:object => 'blueprints'))
+
+        assert_equal %w[multidisk waves], table.rows.map {|r| r[:name] }
+        assert_equal [2, 3], table.rows.map {|r| r[:vm_count] }
+        assert_equal ['group1', 'group1, group2'], table.rows.map {|r| r[:resource_group] }
+        assert_equal OneSwapHelper::VOBJECT::BLUEPRINT, h.instance_variable_get(:@vobject)
+    end
+
+    def test_list_blueprints_needs_no_blueprint_name
+        h, table = lister
+        h.list(:object => 'blueprints', :shift => 'https://s',
+               :shift_user => 'u', :shift_pass => 'p')
+
+        assert_equal 2, table.rows.length
+    end
+
+    def test_missing_credentials_name_the_flags
+        h, = lister
+
+        err = assert_raises(RuntimeError) { h.list(:object => 'blueprints', :shift => 'https://s') }
+
+        assert_includes err.message, '--shift-user'
+        assert_includes err.message, '--shift-pass'
+    end
+
+    def test_listing_vms_requires_a_blueprint
+        h, = lister
+
+        err = assert_raises(RuntimeError) do
+            h.list(:object => 'vms', :shift => 'https://s', :shift_user => 'u', :shift_pass => 'p')
+        end
+
+        assert_includes err.message, '--shift-blueprint'
+    end
+
+    def test_client_errors_become_plain_errors
+        h, = lister(ListShift.new(:vms => NetAppShift::OperationError.new("Blueprint 'x' not found")))
+
+        err = assert_raises(RuntimeError) { h.list(OPTIONS.merge(:object => 'vms')) }
+
+        refute_kind_of NetAppShift::Error, err
+        assert_includes err.message, 'not found'
     end
 
 end

--- a/tests/netapp_shift_mode_test.rb
+++ b/tests/netapp_shift_mode_test.rb
@@ -1,0 +1,289 @@
+# Unit-style checks for the NetApp Shift conversion mode in oneswap_helper.rb.
+# Run with: ruby tests/netapp_shift_mode_test.rb
+
+require 'fileutils'
+require 'logger'
+require 'minitest/autorun'
+require 'tmpdir'
+
+module OpenNebulaHelper
+    class OneHelper; end
+end
+
+module Kernel
+    alias oneswap_test_original_require require
+
+    def require(path)
+        return true if ['one_helper', 'opennebula'].include?(path)
+
+        oneswap_test_original_require(path)
+    end
+end
+
+require_relative '../oneswap_helper'
+
+# Minimal stand-in for Process::Status
+FakeStatus = Struct.new(:ok) do
+    def success?
+        ok
+    end
+end
+
+class NetAppShiftModeTest < Minitest::Test
+
+    def helper(options = {})
+        OneSwapHelper.allocate.tap do |h|
+            h.instance_variable_set(:@options, options)
+            h.instance_variable_set(:@logger, Logger.new(File::NULL))
+        end
+    end
+
+    # Helper wired for run_shift_conversion: n vCenter disks, quiet preflight,
+    # captured commands and imports. Returns [helper, commands, imported].
+    def conversion_helper(mount, work_dir, disk_count, options = {})
+        h = helper({ :name        => 'web01',
+                     :shift       => 'https://shift.local',
+                     :shift_mount => mount,
+                     :work_dir    => work_dir }.merge(options))
+
+        commands = []
+        imported = nil
+
+        h.define_singleton_method(:local_path_image_allocation_preflight!) { nil }
+        h.define_singleton_method(:warn_unreadable_kernel_for_libguestfs) {|_env| nil }
+        h.define_singleton_method(:vc_virtual_disks) { Array.new(disk_count, :disk) }
+        h.define_singleton_method(:new_netapp_shift) {|_opts| NetAppShift::Helper.allocate }
+        h.define_singleton_method(:run_cmd_report) do |cmd, _out = false, **_kw|
+            commands << cmd
+            ['', FakeStatus.new(true)]
+        end
+        h.define_singleton_method(:create_one_images) do |disks|
+            imported = disks
+            [{ :id => 1, :os => false }]
+        end
+        h.instance_variable_set(:@props,
+                                'config' => { :hardware => { :memoryMB => 2048 } })
+
+        [h, commands, proc { imported }]
+    end
+
+    def test_missing_disk_raises_before_any_command
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                h, commands, = conversion_helper(mount, work_dir, 1)
+
+                err = assert_raises(NetAppShift::Error) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'web01.qcow2'
+                assert_empty commands
+            end
+        end
+    end
+
+    def test_single_disk_uses_i_disk_in_place
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                disk = File.join(mount, 'web01.qcow2')
+                File.write(disk, 'x')
+
+                h, commands, imported = conversion_helper(mount, work_dir, 1)
+                h.send(:run_shift_conversion)
+
+                assert_equal 1, commands.size
+                assert_includes commands.first, 'virt-v2v-in-place'
+                assert_includes commands.first, "-i disk #{disk}"
+                assert_includes commands.first, '--machine-readable'
+
+                # imported straight from the mount, no copy anywhere
+                assert_equal [disk], imported.call
+                assert File.exist?(disk)
+                assert_empty Dir.children(work_dir)
+            end
+        end
+    end
+
+    def test_multi_disk_uses_libvirtxml_with_ordered_disks
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                disks = ['web01.qcow2', 'web01_1.qcow2', 'web01_2.qcow2']
+                        .map {|f| File.join(mount, f) }
+                disks.each {|d| File.write(d, 'x') }
+
+                h, commands, imported = conversion_helper(mount, work_dir, 3)
+                h.send(:run_shift_conversion)
+
+                assert_includes commands.first, '-i libvirtxml'
+
+                xml_path = File.join(work_dir, 'web01-shift-domain.xml')
+                assert File.exist?(xml_path)
+
+                xml = File.read(xml_path)
+                # all three disks referenced, in device order
+                positions = disks.map {|d| xml.index("file='#{d}'") }
+                assert positions.all?, "missing disk in domain XML: #{xml}"
+                assert_equal positions.sort, positions
+
+                assert_equal disks, imported.call
+            end
+        end
+    end
+
+    def test_failed_morph_raises_and_skips_import
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+                h, _commands, imported = conversion_helper(mount, work_dir, 1)
+                h.define_singleton_method(:run_cmd_report) do |_cmd, _out = false, **_kw|
+                    ['', FakeStatus.new(false)]
+                end
+
+                err = assert_raises(RuntimeError) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'virt-v2v-in-place failed'
+                assert_nil imported.call
+            end
+        end
+    end
+
+    def test_libguestfs_path_exported_to_command
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                File.write(File.join(mount, 'web01.qcow2'), 'x')
+
+                h, commands, = conversion_helper(mount, work_dir, 1,
+                                                 :libguestfs_path => '/var/lib/one/appliance')
+                h.send(:run_shift_conversion)
+
+                assert_match(%r{^LIBGUESTFS_PATH=/var/lib/one/appliance virt-v2v-in-place},
+                             commands.first)
+            end
+        end
+    end
+
+    def test_zero_disks_raises
+        Dir.mktmpdir do |mount|
+            Dir.mktmpdir do |work_dir|
+                h, = conversion_helper(mount, work_dir, 0)
+
+                err = assert_raises(RuntimeError) { h.send(:run_shift_conversion) }
+
+                assert_includes err.message, 'no virtual disks'
+            end
+        end
+    end
+
+end
+
+# Fake NetAppShift::Helper for orchestration tests
+class FakeShift
+
+    attr_reader :calls
+
+    def initialize(responses = {})
+        @responses = responses
+        @calls     = []
+    end
+
+    def run_compliance_check(bp)
+        @calls << [:compliance, bp]
+        @responses.fetch(:compliance)
+    end
+
+    def trigger_migration(bp)
+        @calls << [:trigger, bp]
+        @responses.fetch(:trigger)
+    end
+
+    def wait_for_completion(bp, exec_id, timeout: nil)
+        @calls << [:wait, bp, exec_id, timeout]
+        @responses.fetch(:wait)
+    end
+
+    def blueprint_vm_names(bp)
+        @calls << [:vm_names, bp]
+        @responses.fetch(:vm_names)
+    end
+
+    def check!(result)
+        raise NetAppShift::OperationError, "failed: #{result.operation}" unless result.ok?
+
+        result
+    end
+
+end
+
+class ShiftExecuteBlueprintTest < Minitest::Test
+
+    OPTIONS = {
+        :shift            => 'https://shift.local',
+        :shift_user       => 'admin',
+        :shift_pass       => 'p',
+        :shift_blueprint  => 'bp1',
+        :shift_wait_timeout => 3600
+    }.freeze
+
+    def result(op, data)
+        NetAppShift::Result.new(op, :data => data, :duration => 0.1)
+    end
+
+    def orchestration_helper(fake)
+        h = OneSwapHelper.allocate
+        h.instance_variable_set(:@logger, Logger.new(File::NULL))
+        h.instance_variable_set(:@verbose, true) # short-circuit apply_verbosity
+        h.define_singleton_method(:check_one_connectivity) { nil }
+        h.define_singleton_method(:local_path_image_allocation_preflight!) { nil }
+        h.define_singleton_method(:new_netapp_shift) {|_opts| fake }
+        h
+    end
+
+    def test_happy_path_passes_blueprint_execution_id_and_timeout
+        fake = FakeShift.new(
+            :compliance => result(:run_compliance_check, :ok => true),
+            :trigger    => result(:trigger_migration, :ok => true, :execution_id => 'ex-9'),
+            :wait       => result(:check_migration_status,
+                                  :ok => true, :status => 'convert_complete')
+        )
+        h = orchestration_helper(fake)
+
+        capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+
+        assert_includes fake.calls, [:compliance, 'bp1']
+        assert_includes fake.calls, [:trigger, 'bp1']
+        assert_includes fake.calls, [:wait, 'bp1', 'ex-9', 3600]
+    end
+
+    def test_missing_execution_id_raises
+        fake = FakeShift.new(
+            :compliance => result(:run_compliance_check, :ok => true),
+            :trigger    => result(:trigger_migration, :ok => true) # no execution_id
+        )
+        h = orchestration_helper(fake)
+
+        err = assert_raises(RuntimeError) do
+            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+        end
+
+        assert_includes err.message, 'no execution id'
+    end
+
+    def test_operation_error_becomes_plain_runtime_error
+        fake = FakeShift.new(:compliance => result(:run_compliance_check, :ok => false))
+        h = orchestration_helper(fake)
+
+        err = assert_raises(RuntimeError) do
+            capture_io { h.shift_execute_blueprint(OPTIONS.dup) }
+        end
+
+        refute_kind_of NetAppShift::OperationError, err
+        assert_includes err.message, 'run_compliance_check'
+    end
+
+    def test_blueprint_vm_names_delegates
+        fake = FakeShift.new(:vm_names => %w[web01 db01])
+        h = orchestration_helper(fake)
+
+        assert_equal %w[web01 db01], h.shift_blueprint_vm_names(OPTIONS.dup)
+    end
+
+end


### PR DESCRIPTION
### Description

This should add NetApp Shift functionality.  The user is required to configure NetApp shift up to the point of having a Blueprint.  Once the blueprint is there, OneSwap will now attempt to run compliance checks and conversion of the VM disks, and then import them using an NFS mount from the OneSwap server. 

There are options to skip compliance, conversion, and OS morphing(virt-v2v-in-place)

virt-v2v-in-place is now required. I had to add `/usr/libexec` to the $PATH. this is clarified in the README. I'll also add it to the docs.

### Branches to which this PR applies

- [x] master
- [ ] one-7.4
